### PR TITLE
Fix DiscordRPC on ARM processors, fixes #153

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,8 @@ dependencies {
         exclude module: 'annotations'
     }
 
+    jarLibs "com.github.cbyrneee:DiscordIPC:e18542f600"
+
     // Add them back to compileOnly (provided)
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion"
     compileOnly 'org.jetbrains:annotations:20.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,6 @@ dependencies {
         exclude module: 'guava'
     }
 
-    jarLibs('club.minnced:java-discord-rpc:2.0.2') {
-        exclude module: 'jna'
-    }
-
     // Kotlin libs
     // kotlin-stdlib-common and annotations aren't required at runtime
     jarLibs("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion") {

--- a/src/main/kotlin/com/lambda/client/LambdaMod.kt
+++ b/src/main/kotlin/com/lambda/client/LambdaMod.kt
@@ -29,7 +29,7 @@ class LambdaMod {
         const val VERSION_SIMPLE = "2.09.xx-dev" // Shown to the user. R.MM.DD[-beta] format.
         const val VERSION_MAJOR = "2.09.01" // Used for update checking. RR.MM.01 format.
 
-        const val APP_ID = "835368493150502923"
+        const val APP_ID = 835368493150502923
 
         const val DOWNLOADS_API = "" // ToDo: setup for CI
         const val CAPES_JSON = "https://raw.githubusercontent.com/lambda-client/cape-api/capes/capes.json"


### PR DESCRIPTION
**Describe the pull**
Fix for crashing on ARM processors by switching to another RPC library

**Describe how this pull is helpful**
Before this, users had to manually remove DiscordRPC and compile the mod themselves, which requires more technical knowledge than most players have and means they can't use the module

**Additional context**
Not tested yet on M1 macs
