### PR TITLE
Fix DiscordRPC error handling

### DIFF
--- a/src/main/kotlin/com/lambda/client/module/modules/misc/DiscordRPC.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/DiscordRPC.kt
@@ -1,9 +1,7 @@
 package com.lambda.client.module.modules.misc
 
 import com.jagrosh.discordipc.IPCClient
-import com.jagrosh.discordipc.IPCListener
 import com.jagrosh.discordipc.entities.RichPresence
-import com.jagrosh.discordipc.entities.User
 import com.jagrosh.discordipc.entities.pipe.PipeStatus
 import com.jagrosh.discordipc.exceptions.NoDiscordClientException
 import com.lambda.capeapi.CapeType
@@ -83,15 +81,11 @@ object DiscordRPC : Module(
         if (isConnected()) return
 
         LambdaMod.LOG.info("Starting Discord RPC")
-        ipc.setListener(object : IPCListener {
-            override fun onReady(client: IPCClient, user: User) {
-                rpcBuilder.setStartTimestamp(OffsetDateTime.now())
-                val richPresence = rpcBuilder.build()
-                ipc.sendRichPresence(richPresence)
-            }
-        })
         try {
             ipc.connect()
+            rpcBuilder.setStartTimestamp(OffsetDateTime.now())
+            val richPresence = rpcBuilder.build()
+            ipc.sendRichPresence(richPresence)
 
             LambdaMod.LOG.info("Discord RPC initialised successfully")
         } catch (e: NoDiscordClientException) {

--- a/src/main/kotlin/com/lambda/client/module/modules/misc/DiscordRPC.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/misc/DiscordRPC.kt
@@ -1,7 +1,9 @@
 package com.lambda.client.module.modules.misc
 
 import com.jagrosh.discordipc.IPCClient
+import com.jagrosh.discordipc.IPCListener
 import com.jagrosh.discordipc.entities.RichPresence
+import com.jagrosh.discordipc.entities.User
 import com.jagrosh.discordipc.entities.pipe.PipeStatus
 import com.jagrosh.discordipc.exceptions.NoDiscordClientException
 import com.lambda.capeapi.CapeType
@@ -81,11 +83,15 @@ object DiscordRPC : Module(
         if (isConnected()) return
 
         LambdaMod.LOG.info("Starting Discord RPC")
+        ipc.setListener(object : IPCListener {
+            override fun onReady(client: IPCClient, user: User) {
+                rpcBuilder.setStartTimestamp(OffsetDateTime.now())
+                val richPresence = rpcBuilder.build()
+                ipc.sendRichPresence(richPresence)
+            }
+        })
         try {
             ipc.connect()
-            rpcBuilder.setStartTimestamp(OffsetDateTime.now())
-            val richPresence = rpcBuilder.build()
-            ipc.sendRichPresence(richPresence)
 
             LambdaMod.LOG.info("Discord RPC initialised successfully")
         } catch (e: NoDiscordClientException) {


### PR DESCRIPTION
**Describe the pull**
This fixes an issue where if discord was closed while discordrpc was running, the background job would constantly try to update it, spamming the log with exceptions, it DOES NOT fix the other discordrpc issues like it crashing the game on freebsd and it not working sometimes for some people (the reason and fix for the latter are still unknown)

**Describe how this pull is helpful**
Log spam is bad

**Additional context**
Please point out any bad code mistakes i made and i can fix them before this is merged, i wrote this while tired :p