### PR TITLE
Add vanilla mode to efly, making optimized pitch corrections

### DIFF
--- a/src/main/java/com/lambda/mixin/entity/MixinEntityLivingBase.java
+++ b/src/main/java/com/lambda/mixin/entity/MixinEntityLivingBase.java
@@ -1,0 +1,132 @@
+package com.lambda.mixin.entity;
+
+import com.lambda.client.module.modules.movement.ElytraFlight;
+import com.lambda.mixin.accessor.AccessorEntityFireworkRocket;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.item.EntityFireworkRocket;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+// This whole thing is dumb and i hate it but i don't think a better way exists -Nep
+@Mixin(EntityLivingBase.class)
+public abstract class MixinEntityLivingBase extends Entity {
+    @Unique
+    private Vec3d modifiedVec = null;
+    
+    public MixinEntityLivingBase(World worldIn) {
+        super(worldIn);
+    }
+
+    @ModifyVariable(
+        method = "travel(FFF)V",
+        at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/entity/EntityLivingBase;getLookVec()Lnet/minecraft/util/math/Vec3d;", ordinal = 0)
+    )
+    private Vec3d vec3d(Vec3d original) {
+        if (shouldWork()) {
+            float negPacketPitch = -ElytraFlight.INSTANCE.getPacketPitch();
+            // Technically from MC but i seriously doubt this is copyrightable
+            float f0 = MathHelper.cos((float) (-this.rotationYaw * 0.017453292f - Math.PI));
+            float f1 = MathHelper.sin((float) (-this.rotationYaw * 0.017453292f - Math.PI));
+            float f2 = -MathHelper.cos(negPacketPitch * 0.017453292f);
+            float f3 = MathHelper.sin(negPacketPitch * 0.017453292f);
+            
+            return new Vec3d(f1 * f2, f3, f0 * f2);
+        }
+        return original;
+    }
+    
+    @ModifyVariable(
+        method = "travel(FFF)V",
+        at = @At(value = "STORE", ordinal = 0),
+        ordinal = 3,
+        print = true
+    )
+    private float f(float original) {
+        if (shouldWork()) {
+            return ElytraFlight.INSTANCE.getPacketPitch() * 0.017453292f;
+        }
+        return original;
+    }
+    
+    @Inject(
+        method = "travel(FFF)V",
+        at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;motionZ:D", ordinal = 3),
+        locals = LocalCapture.CAPTURE_FAILSOFT
+    )
+    private void getVec(
+        float strafe,
+        float vertical,
+        float forward,
+        CallbackInfo ci,
+        // Local capture
+        Vec3d vec3d
+    ) {
+        modifiedVec = vec3d;
+    }
+    
+    // All these redirects are quite silly but oh well
+    
+    @Redirect(
+        method = "travel(FFF)V",
+        at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;motionX:D", ordinal = 7)
+    )
+    public double motionX(EntityLivingBase it) {
+        if (shouldModify()) {
+            it.motionX += modifiedVec.x * 0.1 + (modifiedVec.x * 1.5 - this.motionX) * 0.5;
+        }
+        return it.motionX;
+    }
+    
+    @Redirect(
+        method = "travel(FFF)V",
+        at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;motionY:D", ordinal = 7)
+    )
+    public double motionY(EntityLivingBase it) {
+        if (shouldModify()) {
+            it.motionY += modifiedVec.y * 0.1 + (modifiedVec.y * 1.5 - this.motionY) * 0.5;
+        }
+        return it.motionY;
+    }
+
+    @Redirect(
+        method = "travel(FFF)V",
+        at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;motionZ:D", ordinal = 7)
+    )
+    public double motionZ(EntityLivingBase it) {
+        if (shouldModify()) {
+            it.motionZ += modifiedVec.z * 0.1 + (modifiedVec.z * 1.5 - this.motionZ) * 0.5;
+        }
+        return it.motionZ;
+    }
+    
+    @Unique
+    private boolean shouldWork() {
+        return EntityPlayerSP.class.isAssignableFrom(getClass())
+            && ElytraFlight.INSTANCE.isEnabled()
+            && ElytraFlight.INSTANCE.getMode().getValue() == ElytraFlight.ElytraFlightMode.VANILLA;
+    }
+    
+    @Unique
+    private boolean shouldModify() {
+            return shouldWork() && world.loadedEntityList.stream().anyMatch(entity -> {
+                if (entity instanceof EntityFireworkRocket) {
+                    EntityLivingBase boosted = ((AccessorEntityFireworkRocket) entity).getBoostedEntity();
+                    return boosted != null && boosted.equals(this);
+                }
+                return false;
+            }
+        );
+    }
+}

--- a/src/main/java/com/lambda/mixin/entity/MixinEntityLivingBase.java
+++ b/src/main/java/com/lambda/mixin/entity/MixinEntityLivingBase.java
@@ -50,8 +50,7 @@ public abstract class MixinEntityLivingBase extends Entity {
     @ModifyVariable(
         method = "travel(FFF)V",
         at = @At(value = "STORE", ordinal = 0),
-        ordinal = 3,
-        print = true
+        ordinal = 3
     )
     private float f(float original) {
         if (shouldWork()) {

--- a/src/main/java/com/lambda/mixin/entity/MixinEntityLivingBase.java
+++ b/src/main/java/com/lambda/mixin/entity/MixinEntityLivingBase.java
@@ -19,12 +19,11 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-// This whole thing is dumb and i hate it but i don't think a better way exists -Nep
 @Mixin(EntityLivingBase.class)
 public abstract class MixinEntityLivingBase extends Entity {
     @Unique
     private Vec3d modifiedVec = null;
-    
+
     public MixinEntityLivingBase(World worldIn) {
         super(worldIn);
     }
@@ -36,17 +35,16 @@ public abstract class MixinEntityLivingBase extends Entity {
     private Vec3d vec3d(Vec3d original) {
         if (shouldWork()) {
             float negPacketPitch = -ElytraFlight.INSTANCE.getPacketPitch();
-            // Technically from MC but i seriously doubt this is copyrightable
             float f0 = MathHelper.cos((float) (-this.rotationYaw * 0.017453292f - Math.PI));
             float f1 = MathHelper.sin((float) (-this.rotationYaw * 0.017453292f - Math.PI));
             float f2 = -MathHelper.cos(negPacketPitch * 0.017453292f);
             float f3 = MathHelper.sin(negPacketPitch * 0.017453292f);
-            
+
             return new Vec3d(f1 * f2, f3, f0 * f2);
         }
         return original;
     }
-    
+
     @ModifyVariable(
         method = "travel(FFF)V",
         at = @At(value = "STORE", ordinal = 0),
@@ -58,7 +56,7 @@ public abstract class MixinEntityLivingBase extends Entity {
         }
         return original;
     }
-    
+
     @Inject(
         method = "travel(FFF)V",
         at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;motionZ:D", ordinal = 3),
@@ -74,9 +72,7 @@ public abstract class MixinEntityLivingBase extends Entity {
     ) {
         modifiedVec = vec3d;
     }
-    
-    // All these redirects are quite silly but oh well
-    
+
     @Redirect(
         method = "travel(FFF)V",
         at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;motionX:D", ordinal = 7)
@@ -87,7 +83,7 @@ public abstract class MixinEntityLivingBase extends Entity {
         }
         return it.motionX;
     }
-    
+
     @Redirect(
         method = "travel(FFF)V",
         at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/entity/EntityLivingBase;motionY:D", ordinal = 7)
@@ -109,17 +105,17 @@ public abstract class MixinEntityLivingBase extends Entity {
         }
         return it.motionZ;
     }
-    
+
     @Unique
     private boolean shouldWork() {
         return EntityPlayerSP.class.isAssignableFrom(getClass())
             && ElytraFlight.INSTANCE.isEnabled()
             && ElytraFlight.INSTANCE.getMode().getValue() == ElytraFlight.ElytraFlightMode.VANILLA;
     }
-    
+
     @Unique
     private boolean shouldModify() {
-            return shouldWork() && world.loadedEntityList.stream().anyMatch(entity -> {
+        return shouldWork() && world.loadedEntityList.stream().anyMatch(entity -> {
                 if (entity instanceof EntityFireworkRocket) {
                     EntityLivingBase boosted = ((AccessorEntityFireworkRocket) entity).getBoostedEntity();
                     return boosted != null && boosted.equals(this);

--- a/src/main/kotlin/com/lambda/client/mixin/extension/Misc.kt
+++ b/src/main/kotlin/com/lambda/client/mixin/extension/Misc.kt
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.Chunk
 import net.minecraft.world.chunk.storage.AnvilChunkLoader
 
 val Entity.isInWeb: Boolean get() = (this as AccessorEntity).isInWeb
-val Entity.boostedEntity: EntityLivingBase get() = (this as AccessorEntityFireworkRocket).boostedEntity
+val Entity.boostedEntity: EntityLivingBase? get() = (this as AccessorEntityFireworkRocket).boostedEntity
 
 val ItemTool.attackDamage get() = (this as AccessorItemTool).attackDamage
 

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
@@ -92,7 +92,7 @@ object ElytraFlight : Module(
     /* End of Mode Settings */
 
     private enum class ElytraFlightMode {
-        BOOST, CONTROL, CREATIVE, PACKET
+        BOOST, CONTROL, CREATIVE, PACKET, VANILLA
     }
 
     private enum class Page {
@@ -116,6 +116,11 @@ object ElytraFlight : Module(
     private var packetPitch = 0.0f
     private var hoverState = false
     private var boostingTick = 0
+
+    /* Vanilla mode state */
+    private var lastY = 0.0
+    private var shouldDescend = false
+    private var lastHighY = 0.0
 
     /* Event Listeners */
     init {
@@ -151,6 +156,7 @@ object ElytraFlight : Module(
                         ElytraFlightMode.CONTROL -> controlMode(it)
                         ElytraFlightMode.CREATIVE -> creativeMode()
                         ElytraFlightMode.PACKET -> packetMode(it)
+                        ElytraFlightMode.VANILLA -> vanillaMode()
                     }
                 }
                 spoofRotation()
@@ -343,6 +349,7 @@ object ElytraFlight : Module(
             ElytraFlightMode.CONTROL -> speedControl
             ElytraFlightMode.CREATIVE -> speedCreative
             ElytraFlightMode.PACKET -> speedPacket
+            ElytraFlightMode.VANILLA -> 1f
         }
     }
 
@@ -464,6 +471,21 @@ object ElytraFlight : Module(
         player.motionY = (if (player.movementInput.sneak) -downSpeedPacket else -fallSpeedPacket).toDouble()
 
         event.cancel()
+    }
+
+    private fun SafeClientEvent.vanillaMode() {
+        val playerY = player.posY
+        val lastShouldDescend = shouldDescend
+        shouldDescend = lastY > playerY && lastHighY - 60 < playerY
+        player.rotationPitch = if (shouldDescend) {
+            if (!lastShouldDescend) {
+                lastHighY = playerY
+            }
+            30f
+        } else {
+            -50f
+        }
+        lastY = playerY
     }
 
     fun shouldSwing(): Boolean {

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
@@ -19,7 +19,9 @@ import com.lambda.client.util.threads.safeListener
 import com.lambda.client.util.world.getGroundPos
 import com.lambda.client.util.world.isLiquidBelow
 import com.lambda.client.commons.extension.toRadian
+import com.lambda.client.mixin.extension.boostedEntity
 import net.minecraft.client.audio.PositionedSoundRecord
+import net.minecraft.entity.item.EntityFireworkRocket
 import net.minecraft.init.Items
 import net.minecraft.init.SoundEvents
 import net.minecraft.network.play.client.CPacketEntityAction
@@ -477,7 +479,10 @@ object ElytraFlight : Module(
         val playerY = player.posY
         val lastShouldDescend = shouldDescend
         shouldDescend = lastY > playerY && lastHighY - 60 < playerY
-        player.rotationPitch = if (shouldDescend) {
+        val isBoosted = world.getLoadedEntityList().any { it is EntityFireworkRocket && it.boostedEntity == player }
+        player.rotationPitch = if (isBoosted) {
+            -50f
+        } else if (shouldDescend) {
             if (!lastShouldDescend) {
                 lastHighY = playerY
             }

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
@@ -95,9 +95,9 @@ object ElytraFlight : Module(
 
 
     /* Vanilla */
-    private val upPitch by setting("Up Pitch", 50f,90f..10f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
+    private val upPitch by setting("Up Pitch", 50f,0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
     private val downPitch by setting("Down Pitch", 30f,0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
-    private val rocketPitch by setting("Rocket Pitch", 50f,90f..10f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
+    private val rocketPitch by setting("Rocket Pitch", 50f,0f..90f, 5f, { mode.value == ElytraFlightMode.VANILLA && page == Page.MODE_SETTINGS })
 
     /* End of Mode Settings */
 

--- a/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
+++ b/src/main/kotlin/com/lambda/client/module/modules/movement/ElytraFlight.kt
@@ -486,8 +486,10 @@ object ElytraFlight : Module(
     private fun SafeClientEvent.vanillaMode() {
         val playerY = player.posY
         val lastShouldDescend = shouldDescend
-        shouldDescend = lastY > playerY && lastHighY - 60 < playerY
         val isBoosted = world.getLoadedEntityList().any { it is EntityFireworkRocket && it.boostedEntity == player }
+
+        shouldDescend = lastY > playerY && lastHighY - 60 < playerY
+
         packetPitch = if (isBoosted) {
             -rocketPitch
         } else if (shouldDescend) {
@@ -498,6 +500,7 @@ object ElytraFlight : Module(
         } else {
             -upPitch
         }
+
         lastY = playerY
     }
 
@@ -522,9 +525,7 @@ object ElytraFlight : Module(
                 cancelRotation = isStandingStill && ((!mc.gameSettings.keyBindUseItem.isKeyDown && !mc.gameSettings.keyBindAttack.isKeyDown && blockInteract) || !blockInteract)
             }
         } else if (mode.value == ElytraFlightMode.VANILLA) {
-
             rotation = Vec2f(rotation.x, packetPitch)
-
         }
 
         sendPlayerPacket {

--- a/src/main/resources/mixins.lambda.json
+++ b/src/main/resources/mixins.lambda.json
@@ -35,6 +35,7 @@
     "accessor.render.AccessorViewFrustum",
     "baritone.MixinBaritoneSettings",
     "entity.MixinEntity",
+    "entity.MixinEntityLivingBase",
     "entity.MixinEntityLlama",
     "entity.MixinEntityPig",
     "gui.MixinGuiChat",


### PR DESCRIPTION
**Describe the pull**
Adds a mode to efly that automatically looks up and down for you

**Describe how this pull is helpful**
According to someone i asked this currently works on 2b2t with no lag, though more testing is recommended before merging

**Additional context**
Currently this works by modifying player.rotationPitch, which is not ideal  as it affects the player camera, it is probably possible to spoof it with packets but i have been unsuccessful when i tried, you can commit here if you get it working
