### PR TITLE
Hacky fix for the long lived sporadic clickMouse shadow mixin bug

### DIFF
--- a/src/main/java/com/lambda/mixin/MixinMinecraft.java
+++ b/src/main/java/com/lambda/mixin/MixinMinecraft.java
@@ -43,7 +43,7 @@ public abstract class MixinMinecraft {
     private boolean handActive = false;
     private boolean isHittingBlock = false;
 
-    @Shadow(aliases = "func_147116_af") // Fixes weird prod meme in some cases??
+    @Shadow(aliases = "func_147116_af")
     protected abstract void clickMouse();
 
     @ModifyVariable(method = "displayGuiScreen", at = @At("HEAD"), argsOnly = true)

--- a/src/main/java/com/lambda/mixin/MixinMinecraft.java
+++ b/src/main/java/com/lambda/mixin/MixinMinecraft.java
@@ -43,7 +43,7 @@ public abstract class MixinMinecraft {
     private boolean handActive = false;
     private boolean isHittingBlock = false;
 
-    @Shadow
+    @Shadow(aliases = "func_147116_af()V") // Fixes weird prod meme in some cases??
     protected abstract void clickMouse();
 
     @ModifyVariable(method = "displayGuiScreen", at = @At("HEAD"), argsOnly = true)

--- a/src/main/java/com/lambda/mixin/MixinMinecraft.java
+++ b/src/main/java/com/lambda/mixin/MixinMinecraft.java
@@ -43,7 +43,7 @@ public abstract class MixinMinecraft {
     private boolean handActive = false;
     private boolean isHittingBlock = false;
 
-    @Shadow(aliases = "func_147116_af()V") // Fixes weird prod meme in some cases??
+    @Shadow(aliases = "func_147116_af") // Fixes weird prod meme in some cases??
     protected abstract void clickMouse();
 
     @ModifyVariable(method = "displayGuiScreen", at = @At("HEAD"), argsOnly = true)

--- a/src/main/java/com/lambda/mixin/MixinMinecraft.java
+++ b/src/main/java/com/lambda/mixin/MixinMinecraft.java
@@ -43,7 +43,7 @@ public abstract class MixinMinecraft {
     private boolean handActive = false;
     private boolean isHittingBlock = false;
 
-    @Shadow(aliases = "func_147116_af")
+    @Shadow(aliases = "func_147116_af") // Fixes weird prod meme in some cases??
     protected abstract void clickMouse();
 
     @ModifyVariable(method = "displayGuiScreen", at = @At("HEAD"), argsOnly = true)


### PR DESCRIPTION
**Describe the pull**
It sets an alias containing the srg name of the method in the shadow mixin, which makes mixins work

**Describe how this pull is helpful**
Crashing is bad :P

**Additional context**
This  isn't an ideal fix, it's quite hacky, however until someone figures out what is actually causing the root issue (which no one has in the ~1 year this has been a thing for) it's the best we have
It works on my machine but more testing is recommended before merging
