### PR TITLE
Fix DiscordRPC not working on prod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,11 +97,7 @@ dependencies {
         exclude module: 'kotlin-stdlib-common'
     }
 
-    jarLibs('com.github.cbyrneee:DiscordIPC:e18542f600') {
-        exclude module: 'junixsocket-common'
-        exclude module: 'junixsocket-native-common'
-        exclude module: 'json'
-    }
+    jarLibs 'com.github.cbyrneee:DiscordIPC:e18542f600' // Don't remove transitive dependencies pls :>
 
     // Add them back to compileOnly (provided)
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion"
@@ -167,7 +163,6 @@ jar {
     from {
         exclude '**/module-info.class',
                 'DebugProbesKt.bin',
-                'META-INF/maven/**',
                 'META-INF/proguard/**',
                 'META-INF/versions/**',
                 'META-INF/**.RSA',

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
         exclude module: 'kotlin-stdlib-common'
     }
 
-    jarLibs 'com.github.cbyrneee:DiscordIPC:e18542f600' // Don't remove transitive dependencies pls :>
+    jarLibs 'com.github.cbyrneee:DiscordIPC:e18542f600'
 
     // Add them back to compileOnly (provided)
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion"


### PR DESCRIPTION
**Describe the pull**
Readd DiscordIPC transitive dependencies previously removed, to fix production DiscordRPC

**Describe how this pull is helpful**
It fixes a bug

**Additional context**
I am not sure how this was never noticed until now, considering the breaking change was made in march, but oh well
