### PR TITLE
Add liteloader fix FAQ entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ We recommend using the [Temurin](https://adoptium.net/?variant=openjdk8&jvmVaria
 
 </details>
 
+<details>
+  <summary>... crashing with liteloader?</summary>
+
+> Use liteloader as a forge mod, it is available [here](https://jenkins.liteloader.com/view/1.12.2/job/LiteLoader%201.12.2/lastSuccessfulBuild/artifact/build/libs/liteloader-1.12.2-SNAPSHOT-release.jar)
+</details>
+
 <p align="center">
     <img alt="" src="https://raw.githubusercontent.com/lambda-client/assets/main/footer.png">
 </p>


### PR DESCRIPTION
**Describe the pull**
Tells users to use the nested forge version of liteloader to prevent crashes

**Describe how this pull is helpful**
Liteloader is notably used by world downloader in 1.12.2, a fairly important mod in anarchy servers

**Additional context**
FYI this breakage was actually caused by #251 but i don't think it's a big deal since it can be easily fixed with the instructions here