### PR TITLE
Fix opening URLs on linux without gnome

### DIFF
--- a/src/main/kotlin/com/lambda/client/util/WebUtils.kt
+++ b/src/main/kotlin/com/lambda/client/util/WebUtils.kt
@@ -57,7 +57,14 @@ object WebUtils {
 
     fun openWebLink(url: String) {
         try {
-            Desktop.getDesktop().browse(URI(url))
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                Desktop.getDesktop().browse(URI(url))
+            } else {
+                val exitCode = Runtime.getRuntime().exec(arrayOf("xdg-open", url)).waitFor()
+                if (exitCode != 0) {
+                    LambdaMod.LOG.error("Couldn't open link, xdg-open returned: $exitCode")
+                }
+            }
         } catch (e: IOException) {
             LambdaMod.LOG.error("Couldn't open link: $url")
         }


### PR DESCRIPTION
**Describe the pull**
Uses xdg-open to open links when not in a gnome environment on linux, due to lacking java support

**Describe how this pull is helpful**
Without it the game crashes due to an UnsupportedOperationException :>
