### PR TITLE
Add an alt manager

### DIFF
--- a/src/main/java/com/lambda/mixin/accessor/AccessorMinecraft.java
+++ b/src/main/java/com/lambda/mixin/accessor/AccessorMinecraft.java
@@ -1,6 +1,7 @@
 package com.lambda.mixin.accessor;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.util.Session;
 import net.minecraft.util.Timer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -20,6 +21,9 @@ public interface AccessorMinecraft {
 
     @Accessor("rightClickDelayTimer")
     void setRightClickDelayTimer(int value);
+    
+    @Accessor("session") 
+    void setSession(Session session);
 
     @Invoker("rightClickMouse")
     void invokeRightClickMouse();

--- a/src/main/java/com/lambda/mixin/gui/MixinGuiMultiplayer.java
+++ b/src/main/java/com/lambda/mixin/gui/MixinGuiMultiplayer.java
@@ -1,5 +1,9 @@
 package com.lambda.mixin.gui;
 
+import com.lambda.client.gui.mc.LambdaGuiAltManager;
+import com.lambda.client.manager.managers.AltManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiMultiplayer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.multiplayer.ServerData;
@@ -10,6 +14,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GuiMultiplayer.class)
 public class MixinGuiMultiplayer extends GuiScreen {
+    @Inject(method = "actionPerformed", at = @At("HEAD"))
+    private void actionPerformed(GuiButton button, CallbackInfo ci) {
+        if (button.id == AltManager.BUTTON_ID) {
+            Minecraft.getMinecraft().displayGuiScreen(new LambdaGuiAltManager((GuiMultiplayer) (Object) this));
+        }
+    }
 
     @Inject(method = "connectToServer", at = @At("HEAD"))
     public void connectToServer(ServerData serverData, CallbackInfo ci) {
@@ -18,5 +28,4 @@ public class MixinGuiMultiplayer extends GuiScreen {
             mc.loadWorld(null);
         }
     }
-
 }

--- a/src/main/java/com/lambda/mixin/gui/MixinGuiScreen.java
+++ b/src/main/java/com/lambda/mixin/gui/MixinGuiScreen.java
@@ -1,20 +1,29 @@
 package com.lambda.mixin.gui;
 
+import com.lambda.client.manager.managers.AltManager;
 import com.lambda.client.module.modules.render.ContainerPreview;
 import com.lambda.client.module.modules.render.MapPreview;
 import com.lambda.client.module.modules.render.NoRender;
 import com.lambda.client.util.Wrapper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiMultiplayer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.storage.MapData;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.List;
+
 @Mixin(GuiScreen.class)
 public class MixinGuiScreen {
+    @Shadow
+    protected List<GuiButton> buttonList;
 
     @Inject(method = "renderToolTip", at = @At("HEAD"), cancellable = true)
     public void renderToolTip(ItemStack stack, int x, int y, CallbackInfo ci) {
@@ -34,6 +43,13 @@ public class MixinGuiScreen {
     private void drawWorldBackgroundWrapper(final int tint, final CallbackInfo ci) {
         if (Wrapper.getWorld() != null && NoRender.INSTANCE.isEnabled() && (NoRender.INSTANCE.getInventoryGlobal())) {
             ci.cancel();
+        }
+    }
+    
+    @Inject(method = "setWorldAndResolution", at = @At("TAIL"))
+    private void setWorldAndResolution(Minecraft mc, int width, int height, CallbackInfo ci) {
+        if (GuiMultiplayer.class.isAssignableFrom(getClass())) {
+            buttonList.add(new GuiButton(AltManager.BUTTON_ID, width - 32, height - 20, 32, 20, "Alts"));
         }
     }
 }

--- a/src/main/kotlin/com/lambda/client/gui/mc/LambdaGuiAltManager.kt
+++ b/src/main/kotlin/com/lambda/client/gui/mc/LambdaGuiAltManager.kt
@@ -1,0 +1,98 @@
+package com.lambda.client.gui.mc
+
+import com.lambda.client.manager.managers.AltManager
+import com.lambda.client.util.WebUtils
+import com.lambda.client.util.threads.defaultScope
+import com.lambda.client.util.threads.onMainThread
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import net.minecraft.client.gui.GuiButton
+import net.minecraft.client.gui.GuiMultiplayer
+import net.minecraft.client.gui.GuiScreen
+
+class LambdaGuiAltManager(private val parent: GuiMultiplayer) : GuiScreen() {
+    private var msg = ""
+    private var url: String? = null
+
+    override fun initGui() {
+        addButton(GuiButton(0, 0, height - 20, 50, 20, "Back"))
+        addButton(GuiButton(1, width / 2 - 100, height / 2, "Login"))
+        addButton(GuiButton(2, width / 2 - 100, height / 2 + 350, "Cancel"))
+
+        runBlocking { refreshButtons() }
+    }
+
+    override fun actionPerformed(button: GuiButton) {
+        when (button.id) {
+            0 -> mc.displayGuiScreen(parent)
+            1 -> defaultScope.launch(Dispatchers.IO) {
+                AltManager.login(null, this@LambdaGuiAltManager::showMessage) {
+                    url = null
+                    msg = "Logged in as: $it"
+                    refreshButtons()
+                }
+            }
+            2 -> {
+                url = null
+                msg = ""
+                AltManager.cancel()
+            }
+            else -> defaultScope.launch(Dispatchers.IO) {
+                AltManager.login(buttonList[button.id].displayString, null) {
+                    msg = "Logged in as: $it"
+                }
+            }
+        }
+    }
+
+    override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
+        drawDefaultBackground()
+        super.drawScreen(mouseX, mouseY, partialTicks)
+    }
+
+    override fun drawDefaultBackground() {
+        super.drawDefaultBackground()
+
+        drawCenteredString(mc.fontRenderer, msg, width / 2, height / 2 + 500, 0xFFFFFF)
+    }
+
+    override fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int) {
+        super.mouseClicked(mouseX, mouseY, mouseButton)
+        val halfWidth = mc.fontRenderer.getStringWidth(msg)
+        if (mouseX !in (width / 2 - halfWidth)..(width / 2 + halfWidth)) {
+            return
+        }
+        if (mouseY !in (height / 2 + 500 - mc.fontRenderer.FONT_HEIGHT / 2)..(height / 2 + 500 + mc.fontRenderer.FONT_HEIGHT / 2)) {
+            return
+        }
+
+        if (mouseButton != 0) {
+            return
+        }
+
+        WebUtils.openWebLink(url ?: return)
+    }
+
+    override fun onGuiClosed() {
+        AltManager.cancel()
+    }
+
+    private fun showMessage(code: String, url: String) {
+        msg = "To log in enter the code \"$code\" at $url"
+        setClipboardString(code)
+        this.url = url
+    }
+
+    private suspend fun refreshButtons() {
+        onMainThread {
+            var offset = 0
+            var index = 3
+            buttonList.removeIf { it.id >= index }
+            AltManager.getAccounts().forEach {
+                addButton(GuiButton(index++, width - 100, offset, 100, 20, it.name))
+                offset += 25
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/lambda/client/gui/mc/LambdaGuiAltManager.kt
+++ b/src/main/kotlin/com/lambda/client/gui/mc/LambdaGuiAltManager.kt
@@ -18,7 +18,7 @@ class LambdaGuiAltManager(private val parent: GuiMultiplayer) : GuiScreen() {
     override fun initGui() {
         addButton(GuiButton(0, 0, height - 20, 50, 20, "Back"))
         addButton(GuiButton(1, width / 2 - 100, height / 2, "Login"))
-        addButton(GuiButton(2, width / 2 - 100, height / 2 + 350, "Cancel"))
+        addButton(GuiButton(2, width / 2 - 100, height / 2 + 100, "Cancel"))
 
         runBlocking { refreshButtons() }
     }

--- a/src/main/kotlin/com/lambda/client/gui/mc/LambdaGuiAltManager.kt
+++ b/src/main/kotlin/com/lambda/client/gui/mc/LambdaGuiAltManager.kt
@@ -54,7 +54,7 @@ class LambdaGuiAltManager(private val parent: GuiMultiplayer) : GuiScreen() {
     override fun drawDefaultBackground() {
         super.drawDefaultBackground()
 
-        drawCenteredString(mc.fontRenderer, msg, width / 2, height / 2 + 500, 0xFFFFFF)
+        drawCenteredString(mc.fontRenderer, msg, width / 2, height / 2 + 50, 0xFFFFFF)
     }
 
     override fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int) {
@@ -63,7 +63,7 @@ class LambdaGuiAltManager(private val parent: GuiMultiplayer) : GuiScreen() {
         if (mouseX !in (width / 2 - halfWidth)..(width / 2 + halfWidth)) {
             return
         }
-        if (mouseY !in (height / 2 + 500 - mc.fontRenderer.FONT_HEIGHT / 2)..(height / 2 + 500 + mc.fontRenderer.FONT_HEIGHT / 2)) {
+        if (mouseY !in (height / 2 + 50 - mc.fontRenderer.FONT_HEIGHT / 2)..(height / 2 + 50 + mc.fontRenderer.FONT_HEIGHT / 2)) {
             return
         }
 

--- a/src/main/kotlin/com/lambda/client/manager/managers/AltManager.kt
+++ b/src/main/kotlin/com/lambda/client/manager/managers/AltManager.kt
@@ -185,7 +185,8 @@ object AltManager : Manager {
 
         val body = JsonObject().apply {
             add("Properties", inner)
-            addProperty("RelyingParty", "https://auth.xboxlive.com")
+            // This is xbox live auth semantics, no insecure requests are ever actually made, DO NOT change to https
+            addProperty("RelyingParty", "http://auth.xboxlive.com")
             addProperty("TokenType", "JWT")
         }
 

--- a/src/main/kotlin/com/lambda/client/manager/managers/AltManager.kt
+++ b/src/main/kotlin/com/lambda/client/manager/managers/AltManager.kt
@@ -31,7 +31,7 @@ object AltManager : Manager {
     private val client = HttpClients.createDefault()
     private val type = object : TypeToken<MutableSet<Account>>() {}.type // JVM jank, read TypeToken javadocs
     private val scopes = BasicNameValuePair("scope", "XboxLive.signin offline_access")
-    private val clientId = BasicNameValuePair("client_id", "810b4a0d-7663-4e28-8680-24458240dee4") // TBD
+    private val clientId = BasicNameValuePair("client_id", "a70d663f-9055-4b98-b034-3c77062eead6") // TBD
     private val gson = GsonBuilder().setPrettyPrinting().create()
     private val mtx = Mutex()
 
@@ -185,7 +185,7 @@ object AltManager : Manager {
 
         val body = JsonObject().apply {
             add("Properties", inner)
-            addProperty("RelyingParty", "http://auth.xboxlive.com")
+            addProperty("RelyingParty", "https://auth.xboxlive.com")
             addProperty("TokenType", "JWT")
         }
 

--- a/src/main/kotlin/com/lambda/client/manager/managers/AltManager.kt
+++ b/src/main/kotlin/com/lambda/client/manager/managers/AltManager.kt
@@ -1,0 +1,292 @@
+package com.lambda.client.manager.managers
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.reflect.TypeToken
+import com.lambda.client.LambdaMod
+import com.lambda.client.manager.Manager
+import com.lambda.mixin.accessor.AccessorMinecraft
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import net.minecraft.util.Session
+import org.apache.http.client.entity.UrlEncodedFormEntity
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.message.BasicNameValuePair
+import org.apache.http.util.EntityUtils
+import java.io.File
+import java.io.FileReader
+import java.io.FileWriter
+import java.io.IOException
+
+object AltManager : Manager {
+    const val BUTTON_ID = 26
+
+    private val cache = File(LambdaMod.DIRECTORY, "accounts.json")
+    private val client = HttpClients.createDefault()
+    private val type = object : TypeToken<MutableSet<Account>>() {}.type // JVM jank, read TypeToken javadocs
+    private val scopes = BasicNameValuePair("scope", "XboxLive.signin offline_access")
+    private val clientId = BasicNameValuePair("client_id", "810b4a0d-7663-4e28-8680-24458240dee4") // TBD
+    private val gson = GsonBuilder().setPrettyPrinting().create()
+    private val mtx = Mutex()
+
+    @Volatile
+    private var cancel = false
+
+    suspend fun login(cacheUsername: String?, deviceCodeCallback: ((String, String) -> Unit)?, onCompleted: suspend (String) -> Unit) {
+        mtx.withLock {
+            cancel = false
+            val cacheObj = getAccounts()
+            cacheObj.firstOrNull { it.name == cacheUsername }?.let {
+                try {
+                    setSession(getProfile(it.accessToken), it.accessToken)
+                    onCompleted(it.name)
+                    return@withLock
+                } catch (_: IOException) {
+                    // Goes to bottom
+                }
+            }
+
+            actuallyLogin(cacheUsername, deviceCodeCallback, cacheObj, onCompleted)
+        }
+    }
+
+    fun getAccounts(): MutableSet<Account> {
+        cache.parentFile.mkdirs()
+        cache.createNewFile()
+
+        return FileReader(cache).use { gson.fromJson(it, type) } ?: mutableSetOf()
+    }
+
+    fun cancel() {
+        cancel = true
+    }
+
+    private fun setSession(profile: Profile, token: String) {
+        (mc as AccessorMinecraft).setSession(Session(profile.name, profile.id, token, Session.Type.MOJANG.name))
+    }
+
+    private suspend fun actuallyLogin(
+        cacheUsername: String?,
+        deviceCodeCallback: ((String, String) -> Unit)?,
+        cacheObj: MutableSet<Account>,
+        onCompleted: suspend (String) -> Unit
+    ) {
+        try {
+            val result = oauthOrRefresh(cacheUsername, deviceCodeCallback) ?: return
+            xblAuth(result.accessToken) { xblResp ->
+                val body = gson.fromJson(EntityUtils.toString(xblResp.entity), JsonObject::class.java)
+                val xblToken = body["Token"].asString
+                val userHash = body["DisplayClaims"]
+                    .asJsonObject["xui"]
+                    .asJsonArray[0]
+                    .asJsonObject["uhs"]
+                    .asString
+                val xstsToken = xstsAuth(xblToken)
+                val mcToken = minecraftAuth(xstsToken, userHash) ?: return@xblAuth
+                val profile = getProfile(mcToken)
+                setSession(profile, mcToken)
+                val acct = result.account
+                acct.name = profile.name
+                acct.accessToken = mcToken
+                cacheObj.add(acct)
+
+                FileWriter(cache).use {
+                    gson.toJson(cacheObj, it)
+                }
+                onCompleted(profile.name)
+            }
+        } catch (e: IOException) {
+            LambdaMod.LOG.error("Failed to login", e)
+        }
+    }
+
+    private suspend fun oauthOrRefresh(cacheUsername: String?, deviceCodeCallback: ((String, String) -> Unit)?): MicrosoftTokenData? {
+        if (cache.exists()) {
+            getAccounts().firstOrNull { it.name == cacheUsername }?.let { account ->
+                val req = HttpPost("https://login.microsoftonline.com/consumers/oauth2/v2.0/token").apply {
+                    setHeader("Content-Type", "application/x-www-form-urlencoded")
+                    entity = UrlEncodedFormEntity(
+                        listOf(
+                            clientId,
+                            scopes,
+                            BasicNameValuePair("refresh_token", account.refreshToken),
+                            BasicNameValuePair("grant_type", "refresh_token")
+                        )
+                    )
+                }
+
+                return client.execute(req).use { response ->
+                    val body = gson.fromJson(EntityUtils.toString(response.entity), JsonObject::class.java)
+                    return@use MicrosoftTokenData(body["refresh_token"].asString.also { account.refreshToken = it }, account)
+                }
+            }
+        }
+
+        return oauth(deviceCodeCallback!!)
+    }
+
+    private suspend inline fun oauth(deviceCodeCallback: (String, String) -> Unit): MicrosoftTokenData? {
+        val req = HttpPost("https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode").apply {
+            setHeader("Content-Type", "application/x-www-form-urlencoded")
+            entity = UrlEncodedFormEntity(listOf(clientId, scopes))
+        }
+
+        return client.execute(req).use { httpResp ->
+            val resp = gson.fromJson(EntityUtils.toString(httpResp.entity), JsonObject::class.java)
+            val interval = resp["interval"].asInt
+            val ourCode = resp["device_code"].asString
+
+            deviceCodeCallback(resp["user_code"].asString, resp["verification_uri"].asString)
+
+            while (!cancel) {
+                delay(interval * 1000L)
+                val pollReq = HttpPost("https://login.microsoftonline.com/consumers/oauth2/v2.0/token").apply {
+                    setHeader("Content-Type", "application/x-www-form-urlencoded")
+                    entity = UrlEncodedFormEntity(
+                        listOf(
+                            clientId,
+                            BasicNameValuePair("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                            BasicNameValuePair("device_code", ourCode)
+                        )
+                    )
+                }
+                return@use client.execute(pollReq).use nested@ { pollHttpResp ->
+                    val pollResp = gson.fromJson(EntityUtils.toString(pollHttpResp.entity), JsonObject::class.java)
+                    val error = pollResp["error"]
+                    return@nested if (error == null) {
+                        MicrosoftTokenData(pollResp["access_token"].asString, Account(pollResp["refresh_token"].asString))
+                    } else {
+                        val errorStr = error.asString
+                        if (errorStr != "authorization_pending") {
+                            cancel = false
+                            throw IOException("Failed to poll for device code with error: $errorStr")
+                        }
+                        return@nested null
+                    }
+                } ?: continue
+            }
+            cancel = false
+            return@use null
+        }
+    }
+
+    private inline fun xblAuth(token: String, handler: (CloseableHttpResponse) -> Unit) {
+        val inner = JsonObject().apply {
+            addProperty("AuthMethod", "RPS")
+            addProperty("SiteName", "user.auth.xboxlive.com")
+            addProperty("RpsTicket", "d=$token")
+        }
+
+        val body = JsonObject().apply {
+            add("Properties", inner)
+            addProperty("RelyingParty", "http://auth.xboxlive.com")
+            addProperty("TokenType", "JWT")
+        }
+
+        val req = HttpPost("https://user.auth.xboxlive.com/user/authenticate").apply {
+            entity = StringEntity(body.toString())
+            setHeader("Content-Type", "application/json")
+            setHeader("Accept", "application/json")
+        }
+
+        client.execute(req).use(handler)
+    }
+
+    private fun xstsAuth(token: String): String {
+        val tokenArray = JsonArray().apply { add(token) }
+        val inner = JsonObject().apply {
+            addProperty("SandboxId", "RETAIL")
+            add("UserTokens", tokenArray)
+        }
+
+        val body = JsonObject().apply {
+            add("Properties", inner)
+            addProperty("RelyingParty", "rp://api.minecraftservices.com/")
+            addProperty("TokenType", "JWT")
+        }
+
+        val req = HttpPost("https://xsts.auth.xboxlive.com/xsts/authorize").apply {
+            entity = StringEntity(body.toString())
+            setHeader("Content-Type", "application/json")
+            setHeader("Accept", "application/json")
+        }
+
+        return client.execute(req).use {
+            val respBody = gson.fromJson(EntityUtils.toString(it.entity), JsonObject::class.java)
+            if (it.statusLine.statusCode == 401) {
+                throw IOException("XSTS returned 401 with XErr: " + respBody["XErr"].asLong)
+            }
+
+            return@use respBody["Token"].asString
+        }
+    }
+
+    private fun minecraftAuth(token: String, userHash: String): String? {
+        val body = JsonObject().apply { addProperty("identityToken", "XBL3.0 x=$userHash;$token") }
+        val req = HttpPost("https://api.minecraftservices.com/authentication/login_with_xbox").apply {
+            entity = StringEntity(body.toString())
+            setHeader("Content-Type", "application/json")
+            setHeader("Accept", "application/json")
+        }
+
+        return client.execute(req).use {
+            if (it.statusLine.statusCode == 200) {
+                return@use gson.fromJson(EntityUtils.toString(it.entity), JsonObject::class.java)["access_token"].asString
+            }
+
+            return@use null
+        }
+    }
+
+    private fun getProfile(token: String): Profile {
+        val req = HttpGet("https://api.minecraftservices.com/minecraft/profile").apply {
+            setHeader("Authorization", "Bearer $token")
+        }
+
+        return client.execute(req).use {
+            val status = it.statusLine.statusCode
+            if (status == 200) {
+                return@use gson.fromJson(EntityUtils.toString(it.entity), Profile::class.java)
+            }
+
+            LambdaMod.LOG.error("Failed to get alt profile: $status")
+            throw IOException()
+        }
+    }
+
+    class Account(var refreshToken: String = "") {
+        lateinit var name: String
+        lateinit var accessToken: String
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) {
+                return true
+            }
+            if (other == null || javaClass != other.javaClass) {
+                return false
+            }
+
+            return name == (other as Account).name
+        }
+
+        override fun hashCode(): Int {
+            return name.hashCode()
+        }
+    }
+
+    class MicrosoftTokenData(
+        val accessToken: String,
+        val account: Account
+    )
+
+    class Profile {
+        lateinit var name: String
+        lateinit var id: String
+    }
+}


### PR DESCRIPTION
**Describe the pull**
It will, when ready, add an alt manager GUI to lambda

**Describe how this pull is helpful**
Many people like alt managers, and it can be useful for dev environments

**Additional context**
This is *not* ready to be merged, it is very untested and in the ways it was tested it does not work yet, i am releasing this draft PR to request assistance to figure out the bugs, first of all the  "Cancel" button never appearing
Another thing that should be changed before merging is the oauth client id to an official lambda one
