### PR TITLE
[1.20.x] [NeoForge] Access Transformers not applied in production

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
   "depends": {
     "fabricloader": ">=${fabricLoaderVersion}",
     "fabric-api": ">=${fabricApiVersion}+${minecraftVersion}",
-    "minecraft": ">=${minecraftVersion}",
+    "minecraft": "~${minecraftVersion}",
     "fabric-language-kotlin": ">=${kotlinFabricVersion}",
     "java": ">=${javaVersion}"
   }

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -15,20 +15,20 @@ displayTest = "IGNORE_ALL_VERSION"
 [[dependencies.${modId}]]
 modId = "forge"
 mandatory = true
-versionRange = "[${forgeVersion},)"
+versionRange = "[${forgeVersionMin},${forgeVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"
 
 [[dependencies.${modId}]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[${minecraftVersion},)"
+versionRange = "[${minecraftVersionMin},${minecraftVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"
 
 [[dependencies.${modId}]]
 modId = "kotlinforforge"
 mandatory = true
-versionRange = "[${kotlinForgeVersion},)"
+versionRange = "[${kotlinForgeVersionMin},${kotlinForgeVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,8 @@ modAuthors=Constructor, Blade, Edouard127
 
 # General
 minecraftVersion=1.20.4
+minecraftVersionMin=1.20.3
+minecraftVersionMax=1.20.4
 mixinExtrasVersion=0.3.6
 kotlinVersion=2.0.0
 kotlinxCoroutinesVersion=1.9.0-RC
@@ -19,12 +21,17 @@ fabricApiVersion=0.97.1
 kotlinFabricVersion=1.11.0+kotlin.2.0.0
 
 # Forge https://files.minecraftforge.net/
-# Please do not change this version it will implode and create a black hole
 forgeVersion=49.0.31
+forgeVersionMin=44
+forgeVersionMax=49.999.0
 kotlinForgeVersion=4.11.0
+kotlinForgeVersionMin=4.0.0
+kotlinForgeVersionMax=4.11.0
 
 # NeoForge https://neoforged.net
 neoVersion=20.4.237
+neoVersionMin=20.2.3-beta
+neoVersionMax=20.999.0
 
 # Kotlin https://kotlinlang.org/
 kotlin.code.style=official

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -91,5 +91,7 @@ tasks {
 
         archiveVersion = "$modVersion+$minecraftVersion"
         inputFile = shadowJar.get().archiveFile
+
+        atAccessWideners.add("lambda.accesswidener")
     }
 }

--- a/neoforge/src/main/resources/META-INF/mods.toml
+++ b/neoforge/src/main/resources/META-INF/mods.toml
@@ -20,7 +20,7 @@ config = "lambda.mixins.common.json"
 modId = "neoforge"
 mandatory = true
 type = "required"
-versionRange = "[${neoVersion},)"
+versionRange = "[${neoVersionMin},${neoVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"
 
@@ -28,7 +28,7 @@ side = "CLIENT"
 modId = "minecraft"
 mandatory = true
 type = "required"
-versionRange = "[${minecraftVersion},)"
+versionRange = "[${minecraftVersionMin},${minecraftVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"
 
@@ -36,6 +36,6 @@ side = "CLIENT"
 modId = "kotlinforforge"
 mandatory = true
 type = "required"
-versionRange = "[${kotlinForgeVersion},)"
+versionRange = "[${kotlinForgeVersionMin},${kotlinForgeVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -20,7 +20,7 @@ config = "lambda.mixins.common.json"
 modId = "neoforge"
 mandatory = true
 type = "required"
-versionRange = "[${neoVersion},)"
+versionRange = "[${neoVersionMin},${neoVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"
 
@@ -28,7 +28,7 @@ side = "CLIENT"
 modId = "minecraft"
 mandatory = true
 type = "required"
-versionRange = "[${minecraftVersion},)"
+versionRange = "[${minecraftVersionMin},${minecraftVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"
 
@@ -36,6 +36,6 @@ side = "CLIENT"
 modId = "kotlinforforge"
 mandatory = true
 type = "required"
-versionRange = "[${kotlinForgeVersion},)"
+versionRange = "[${kotlinForgeVersionMin},${kotlinForgeVersionMax}]"
 ordering = "NONE"
 side = "CLIENT"


### PR DESCRIPTION
This pull requests fixes #34 by adding the access widener configuration file in the NeoForge's build file remapJar task