### PR TITLE
[1.20.4] [All] Bug: Inconsistent run in dev environment

### DIFF
--- a/common/src/main/kotlin/com/lambda/command/CommandRegistry.kt
+++ b/common/src/main/kotlin/com/lambda/command/CommandRegistry.kt
@@ -12,9 +12,7 @@ object CommandRegistry : Configurable(LambdaConfig), Loadable {
     override val name = "command"
     val prefix by setting("prefix", ';')
 
-    val commands = getInstances<LambdaCommand> {
-        forPackages("com.lambda.command.commands"); filterInputsBy { it.contains("com.lambda") }
-    }.toMutableList()
+    val commands = getInstances<LambdaCommand> { forPackages("com.lambda.command.commands") }.toMutableList()
 
     override fun load(): String {
         return "Registered ${commands.size} commands"

--- a/common/src/main/kotlin/com/lambda/module/ModuleRegistry.kt
+++ b/common/src/main/kotlin/com/lambda/module/ModuleRegistry.kt
@@ -10,9 +10,7 @@ import org.reflections.util.ConfigurationBuilder
  * The [ModuleRegistry] object is responsible for managing all [Module] instances in the system.
  */
 object ModuleRegistry : Loadable {
-    val modules = getInstances<Module> {
-        forPackages("com.lambda.module.modules"); filterInputsBy { it.contains("com.lambda") }
-    }.toMutableList()
+    val modules = getInstances<Module> { forPackages("com.lambda.module.modules") }.toMutableList()
 
     val moduleNames: Set<String>
         get() = modules.map { it.name }.toSet()

--- a/common/src/main/kotlin/com/lambda/util/reflections/ReflectionsConfigDsl.kt
+++ b/common/src/main/kotlin/com/lambda/util/reflections/ReflectionsConfigDsl.kt
@@ -18,7 +18,6 @@ class ReflectionConfigDsl {
     private val packages = mutableListOf<String>()
     private val scanners = mutableListOf<Scanners>()
     private val urls = mutableListOf<URL>()
-    private var inputsFilter: (String) -> Boolean = { true }
     private val classLoaders = mutableListOf<ClassLoader>()
     private var parallel = false
     private var shouldExpandSuperTypes = true
@@ -57,17 +56,6 @@ class ReflectionConfigDsl {
     }
 
     /**
-     * Sets a filter for input names.
-     *
-     * @param filter A lambda function that takes a [String] and returns a [Boolean], indicating whether the input should be included.
-     * @return The current instance of [ReflectionConfigDsl] for method chaining.
-     */
-    fun filterInputsBy(filter: (String) -> Boolean): ReflectionConfigDsl {
-        inputsFilter = filter
-        return this
-    }
-
-    /**
      * Adds class loaders to the configuration.
      *
      * @param classLoaders A vararg of [ClassLoader] to be used in the scanning process.
@@ -101,13 +89,11 @@ class ReflectionConfigDsl {
 
     /**
      * Builds a [ConfigurationBuilder] based on the current configuration.
-     *
-     * @return A [ConfigurationBuilder] configured with the specified packages, scanners, URLs, filters, and class loaders.
      */
     fun build(): ConfigurationBuilder = ConfigurationBuilder()
         .forPackages(*packages.toTypedArray())
         .addUrls(*urls.toTypedArray())
-        .filterInputsBy(inputsFilter)
+        .filterInputsBy { it.contains("com.lambda") }
         .addClassLoaders(*classLoaders.toTypedArray())
         .setExpandSuperTypes(shouldExpandSuperTypes)
 }

--- a/common/src/main/kotlin/com/lambda/util/reflections/ReflectionsConfigDsl.kt
+++ b/common/src/main/kotlin/com/lambda/util/reflections/ReflectionsConfigDsl.kt
@@ -12,6 +12,11 @@ annotation class ReflectionsDsl
  * A DSL class to configure the Reflections library for runtime scanning.
  * This class allows you to specify packages, scanners, URLs, filters, class loaders, and other options
  * to build a Reflections configuration.
+ *
+ * Important!!
+ * Be aware that using Reflections can lead to unpredictable and hard-to-debug issues.
+ * Furthermore, the library we're relying on is outdated and no longer maintained.
+ * For more reliable methods, refer to Reflections.kt.
  */
 @ReflectionsDsl
 class ReflectionConfigDsl {
@@ -19,72 +24,50 @@ class ReflectionConfigDsl {
     private val scanners = mutableListOf<Scanners>()
     private val urls = mutableListOf<URL>()
     private val classLoaders = mutableListOf<ClassLoader>()
-    private var parallel = false
+
     private var shouldExpandSuperTypes = true
 
     /**
      * Specifies the packages to be scanned.
      *
      * @param packages A vararg of package names to be included in the scanning process.
-     * @return The current instance of [ReflectionConfigDsl] for method chaining.
      */
-    fun forPackages(vararg packages: String): ReflectionConfigDsl {
+    fun forPackages(vararg packages: String) {
         this.packages += packages
-        return this
     }
 
     /**
      * Adds scanners to the configuration.
      *
      * @param scanners A vararg of [Scanners] to be used for scanning classes, methods, etc.
-     * @return The current instance of [ReflectionConfigDsl] for method chaining.
      */
-    fun addScanners(vararg scanners: Scanners): ReflectionConfigDsl {
+    fun addScanners(vararg scanners: Scanners) {
         this.scanners += scanners
-        return this
     }
 
     /**
      * Adds URLs to the configuration.
      *
      * @param urls A vararg of [URL] to be included in the scanning process.
-     * @return The current instance of [ReflectionConfigDsl] for method chaining.
      */
-    fun addUrls(vararg urls: URL): ReflectionConfigDsl {
+    fun addUrls(vararg urls: URL) {
         this.urls += urls
-        return this
     }
 
     /**
      * Adds class loaders to the configuration.
      *
      * @param classLoaders A vararg of [ClassLoader] to be used in the scanning process.
-     * @return The current instance of [ReflectionConfigDsl] for method chaining.
      */
-    fun addClassLoaders(vararg classLoaders: ClassLoader): ReflectionConfigDsl {
+    fun addClassLoaders(vararg classLoaders: ClassLoader) {
         this.classLoaders += classLoaders
-        return this
     }
 
     /**
-     * Enables parallel scanning.
-     *
-     * @return The current instance of [ReflectionConfigDsl] for method chaining.
+     * Expand super types during the scan
      */
-    fun parallel(): ReflectionConfigDsl {
-        parallel = true
-        return this
-    }
-
-    /**
-     * Sets whether to expand super types during scanning.
-     *
-     * @param value A [Boolean] indicating whether to expand super types.
-     * @return The current instance of [ReflectionConfigDsl] for method chaining.
-     */
-    fun expandSuperTypes(value: Boolean): ReflectionConfigDsl {
-        shouldExpandSuperTypes = value
-        return this
+    fun expandSuperTypes(shouldExpand: Boolean) {
+        shouldExpandSuperTypes = shouldExpand
     }
 
     /**
@@ -93,7 +76,6 @@ class ReflectionConfigDsl {
     fun build(): ConfigurationBuilder = ConfigurationBuilder()
         .forPackages(*packages.toTypedArray())
         .addUrls(*urls.toTypedArray())
-        .filterInputsBy { it.contains("com.lambda") }
         .addClassLoaders(*classLoaders.toTypedArray())
         .setExpandSuperTypes(shouldExpandSuperTypes)
 }


### PR DESCRIPTION
After multiple hours of excruciating pain and mental breakdowns, I have found that `org.reflections` was schizoing about input filters.

The fix ?
Don't filter anything, just don't.
