### PR TITLE
Self-hosted runners for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build:
     name: Build Lambda
-    runs-on: ubuntu-latest
+    runs-on: lambda-linux-runner
     permissions:
       contents: write
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set runner
         id: set-runner
         run: |
-          runners=$(curl -w "%{http_code}" -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners")
+          runners=$(curl -v -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners")
           available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
           if [ -n "$available" ]; then
             echo "runner-label=self-hosted" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,12 @@ jobs:
           runners=$(curl -v -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners" --http1.1)
           if [ $? -ne 0 ]; then
             echo "Error: Failed to fetch runners from GitHub API" >&2
+            exit 1
+          fi
+
+          runners_count=$(echo "$runners" | jq '.runners | length')
+          if [ "$runners_count" -eq 0 ]; then
+            echo "No runners available or failed to retrieve runners." >&2
             echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -28,11 +34,9 @@ jobs:
           available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
           if [ $? -ne 0 ]; then
             echo "Error: Failed to parse JSON response" >&2
-            echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
-            exit 0
+            exit 1
           fi
     
-          # Decide the runner label based on availability
           if [ -n "$available" ]; then
             echo "runner-label=self-hosted" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set runner
         id: set-runner
         run: |
-          runners=$(curl -v -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners")
+          runners=$(curl -v -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners" --http1.1)
           available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
           if [ -n "$available" ]; then
             echo "runner-label=self-hosted" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           all: true
 
       - name: Build Lambda
-        run: ./gradlew --build-cache build
+        run: ./gradlew build --no-daemon
 
       - name: Upload Lambda
         uses: ryand56/r2-upload-action@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set runner
         id: set-runner
         run: |
-          runners=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners" -w "%{http_code}")
+          runners=$(curl -w "%{http_code}" -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners")
           available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
           if [ -n "$available" ]; then
             echo "runner-label=self-hosted" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           fi
     
           if [ -n "$available" ]; then
-            echo "runner-label=self-hosted" >> $GITHUB_OUTPUT
+            echo "runner-label=lambda-linux-runner" >> $GITHUB_OUTPUT
           else
             echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,6 @@ jobs:
           java-version: '17'
           architecture: x64
           cache: 'gradle'
-          cache-dependency-path: |
-            build.gradle.kts
 
       - name: Read Gradle Properties
         uses: BrycensRanch/read-properties-action@v1.0.4
@@ -91,7 +89,7 @@ jobs:
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
           source-dir: |
-            fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}
-            forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}
-            common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}
+            fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar
+            forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar
+            common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  check-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.set-runner.outputs.runner-label }}
+
+    steps:
+      - name: Set runner
+        id: set-runner
+        run: |
+          runners=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners")
+          available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
+          if [ -n "$available" ]; then
+            echo "runner-label=self-hosted" >> $GITHUB_OUTPUT
+          else
+            echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
+          fi
   build:
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner-label }}
+    
     name: Build Lambda
-    runs-on: lambda-linux-runner
     permissions:
       contents: write
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   check-runner:
     runs-on: ubuntu-latest
+    
     outputs:
       runner-label: ${{ steps.set-runner.outputs.runner-label }}
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           all: true
 
       - name: Build Lambda
-        run: ./gradlew build --no-daemon
+        run: ./gradlew build
         
       - name: Upload Lambda Fabric
         uses: ryand56/r2-upload-action@latest
@@ -88,7 +88,7 @@ jobs:
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          source-dir: 'fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          source-dir: './fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
           
       - name: Upload Lambda Forge
@@ -98,7 +98,7 @@ jobs:
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          source-dir: 'forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          source-dir: './forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
 
       - name: Upload Lambda API
@@ -108,5 +108,5 @@ jobs:
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          source-dir: 'common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          source-dir: './common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set runner
         id: set-runner
         run: |
-          runners=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners")
+          runners=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners" -w "%{http_code}")
           available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
           if [ -n "$available" ]; then
             echo "runner-label=self-hosted" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,16 +80,33 @@ jobs:
 
       - name: Build Lambda
         run: ./gradlew build --no-daemon
-
-      - name: Upload Lambda
+        
+      - name: Upload Lambda Fabric
         uses: ryand56/r2-upload-action@latest
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          source-dir: |
-            fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar
-            forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar
-            common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar
+          source-dir: 'fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
+          
+      - name: Upload Lambda Forge
+        uses: ryand56/r2-upload-action@latest
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
+          r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: 'forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
+
+      - name: Upload Lambda API
+        uses: ryand56/r2-upload-action@latest
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
+          r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: 'common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       runner-label: ${{ steps.set-runner.outputs.runner-label }}
-
+    
     steps:
       - name: Set runner
         id: set-runner
         run: |
           runners=$(curl -v -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners" --http1.1)
+          if [ $? -ne 0 ]; then
+            echo "Error: Failed to fetch runners from GitHub API" >&2
+            echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+    
           available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
+          if [ $? -ne 0 ]; then
+            echo "Error: Failed to parse JSON response" >&2
+            echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+    
+          # Decide the runner label based on availability
           if [ -n "$available" ]; then
             echo "runner-label=self-hosted" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4.1.1
 
+      - name: Set current date as env variable
+        run: echo "DATE=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
+
       - name: Get Short Commit Hash
         id: vars
         run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -80,20 +83,15 @@ jobs:
       - name: Build Lambda
         run: ./gradlew --build-cache build
 
-      - name: Upload Lambda Fabric
-        uses: actions/upload-artifact@v4.3.6
+      - name: Upload Lambda
+        uses: ryand56/r2-upload-action@latest
         with:
-          name: lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}-${{ env.COMMIT_HASH }}
-          path: fabric/build/libs/
-
-      - name: Upload Lambda Forge
-        uses: actions/upload-artifact@v4.3.6
-        with:
-          name: lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}-${{ env.COMMIT_HASH }}
-          path: forge/build/libs/
-
-      - name: Upload Lambda API
-        uses: actions/upload-artifact@v4.3.6
-        with:
-          name: lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}-${{ env.COMMIT_HASH }}
-          path: common/build/libs/
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
+          r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: |
+            fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}
+            forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}
+            common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}
+          destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_and_release:
-    name: Build and Release Lambda
+  check-runner:
     runs-on: ubuntu-latest
+    
+    outputs:
+      runner-label: ${{ steps.set-runner.outputs.runner-label }}
+    
+    steps:
+      - name: Set runner
+        id: set-runner
+        run: |
+          runners=$(curl -v -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.REPO_ACCESS_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runners" --http1.1)
+          if [ $? -ne 0 ]; then
+            echo "Error: Failed to fetch runners from GitHub API" >&2
+            exit 1
+          fi
+
+          runners_count=$(echo "$runners" | jq '.runners | length')
+          if [ "$runners_count" -eq 0 ]; then
+            echo "No runners available or failed to retrieve runners." >&2
+            echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+    
+          available=$(echo "$runners" | jq '.runners[] | select(.status == "online" and .busy == false and .labels[] .name == "self-hosted")')
+          if [ $? -ne 0 ]; then
+            echo "Error: Failed to parse JSON response" >&2
+            exit 1
+          fi
+    
+          if [ -n "$available" ]; then
+            echo "runner-label=lambda-linux-runner" >> $GITHUB_OUTPUT
+          else
+            echo "runner-label=ubuntu-latest" >> $GITHUB_OUTPUT
+          fi
+  build:
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner-label }}
+    
+    name: Build and Release Lambda
     permissions:
       contents: write
     env:
@@ -20,6 +56,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.1.1
+
+      - name: Set current date as env variable
+        run: echo "DATE=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
 
       - name: Get Short Commit Hash
         id: vars
@@ -32,8 +71,6 @@ jobs:
           java-version: '17'
           architecture: x64
           cache: 'gradle'
-          cache-dependency-path: |
-            build.gradle.kts
 
       - name: Read Gradle Properties
         uses: BrycensRanch/read-properties-action@v1.0.4
@@ -43,25 +80,37 @@ jobs:
           all: true
 
       - name: Build Lambda
-        run: ./gradlew --build-cache build
-
+        run: ./gradlew build --no-daemon
+        
       - name: Upload Lambda Fabric
-        uses: actions/upload-artifact@v4.3.6
+        uses: ryand56/r2-upload-action@latest
         with:
-          name: lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}-${{ env.COMMIT_HASH }}
-          path: fabric/build/libs/
-
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
+          r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: 'fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
+          
       - name: Upload Lambda Forge
-        uses: actions/upload-artifact@v4.3.6
+        uses: ryand56/r2-upload-action@latest
         with:
-          name: lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}-${{ env.COMMIT_HASH }}
-          path: forge/build/libs/
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
+          r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: 'forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
 
       - name: Upload Lambda API
-        uses: actions/upload-artifact@v4.3.6
+        uses: ryand56/r2-upload-action@latest
         with:
-          name: lambda-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}-${{ env.COMMIT_HASH }}
-          path: common/build/libs/
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
+          r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: 'common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2.0.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,8 @@ jobs:
           all: true
 
       - name: Build Lambda
-        run: ./gradlew build --no-daemon
-        
+        run: ./gradlew build
+
       - name: Upload Lambda Fabric
         uses: ryand56/r2-upload-action@latest
         with:
@@ -89,9 +89,9 @@ jobs:
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          source-dir: 'fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          source-dir: './fabric/build/libs/lambda-fabric-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
-          
+
       - name: Upload Lambda Forge
         uses: ryand56/r2-upload-action@latest
         with:
@@ -99,7 +99,7 @@ jobs:
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          source-dir: 'forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          source-dir: './forge/build/libs/lambda-forge-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
 
       - name: Upload Lambda API
@@ -109,7 +109,7 @@ jobs:
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY }}
           r2-secret-access-key: ${{ secrets.R2_ACCESS_SECRET }}
           r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
-          source-dir: 'common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
+          source-dir: './common/build/libs/lambda-api-${{ steps.all.outputs.modVersion }}+${{ steps.all.outputs.minecraftVersion }}.jar'
           destination-dir: ${{ env.DATE }}-${{ env.COMMIT_HASH }}
 
       - name: Create Release

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,11 @@
+val modVersion: String by project
+val minecraftVersion: String by project
 val modId: String by project
 val fabricLoaderVersion: String by project
 val kotlinxCoroutinesVersion: String by project
 val discordIPCVersion: String by project
+
+base.archivesName = "${base.archivesName.get()}-api"
 
 architectury { common("fabric", "forge") }
 
@@ -31,6 +35,12 @@ dependencies {
     modImplementation("baritone-api:baritone-unoptimized-fabric:1.10.2")
 }
 
-tasks.test {
-    useJUnitPlatform()
+tasks {
+    remapJar {
+        archiveVersion = "$modVersion+$minecraftVersion"
+    }
+
+    test {
+        useJUnitPlatform()
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,6 @@ kotlinForgeVersionMax=4.11.0
 kotlin.code.style=official
 
 # Gradle https://gradle.org/
-org.gradle.jvmargs=-Xmx2048M \
-  -XX:MaxMetaspaceSize=256m \
+org.gradle.jvmargs=-Xmx8192M \
   -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
**What does this PR do?**
It changes the build workflow to utilize our newly installed self-hosted runners

**Why is this change needed?**
We need these runners to circumvent the free GitHub compute time
