### PR TITLE
Listener semmantics and dynamic scheduling

### DIFF
--- a/common/src/main/kotlin/com/lambda/config/Configuration.kt
+++ b/common/src/main/kotlin/com/lambda/config/Configuration.kt
@@ -24,7 +24,7 @@ import com.lambda.Lambda.LOG
 import com.lambda.Lambda.gson
 import com.lambda.config.configurations.ModuleConfig
 import com.lambda.event.events.ClientEvent
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeListener
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.threading.runIO
 import com.lambda.util.Communication.info
 import com.lambda.util.Communication.logError
@@ -57,9 +57,9 @@ abstract class Configuration : Jsonable {
         get() = File("${primary.parent}/${primary.nameWithoutExtension}-backup.${primary.extension}")
 
     init {
-        unsafeListener<ClientEvent.Startup> { tryLoad() }
+        listenUnsafe<ClientEvent.Startup> { tryLoad() }
 
-        unsafeListener<ClientEvent.Shutdown>(Int.MIN_VALUE) { trySave() }
+        listenUnsafe<ClientEvent.Shutdown>(Int.MIN_VALUE) { trySave() }
 
         register()
     }

--- a/common/src/main/kotlin/com/lambda/core/PingManager.kt
+++ b/common/src/main/kotlin/com/lambda/core/PingManager.kt
@@ -19,7 +19,7 @@ package com.lambda.core
 
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.util.collections.LimitedOrderedSet
 import net.minecraft.network.packet.c2s.query.QueryPingC2SPacket
 import net.minecraft.network.packet.s2c.query.PingResultS2CPacket
@@ -33,12 +33,12 @@ object PingManager : Loadable {
         get() = pings.lastOrNull() ?: 0
 
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             connection.sendPacket(QueryPingC2SPacket(Util.getMeasuringTimeMs()))
         }
 
-        listener<PacketEvent.Receive.Pre> { event ->
-            if (event.packet !is PingResultS2CPacket) return@listener
+        listen<PacketEvent.Receive.Pre> { event ->
+            if (event.packet !is PingResultS2CPacket) return@listen
 
             pings.add(Util.getMeasuringTimeMs() - event.packet.startTime)
         }

--- a/common/src/main/kotlin/com/lambda/event/EventFlow.kt
+++ b/common/src/main/kotlin/com/lambda/event/EventFlow.kt
@@ -66,7 +66,7 @@ object EventFlow {
      * the oldest event will be dropped to accommodate a new event.
      */
     val concurrentFlow = MutableSharedFlow<Event>(
-        extraBufferCapacity = 1000,
+        extraBufferCapacity = 10000,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
 

--- a/common/src/main/kotlin/com/lambda/event/listener/SafeListener.kt
+++ b/common/src/main/kotlin/com/lambda/event/listener/SafeListener.kt
@@ -26,6 +26,8 @@ import com.lambda.threading.runConcurrent
 import com.lambda.threading.runSafe
 import com.lambda.util.Pointer
 import com.lambda.util.selfReference
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlin.properties.ReadOnlyProperty
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
@@ -99,11 +101,11 @@ class SafeListener<T : Event>(
          *
          * Usage:
          * ```kotlin
-         * listener<MyEvent> { event ->
+         * listen<MyEvent> { event ->
          *     player.sendMessage("Event received: $event")
          * }
          *
-         * listener<MyEvent>(priority = 1) { event ->
+         * listen<MyEvent>(priority = 1) { event ->
          *     player.sendMessage("Event received before the previous listener: $event")
          * }
          * ```
@@ -114,7 +116,7 @@ class SafeListener<T : Event>(
          * @param function The function to be executed when the event is posted. This function should take a SafeContext and an event of type T as parameters.
          * @return The newly created and registered [SafeListener].
          */
-        inline fun <reified T : Event> Any.listener(
+        inline fun <reified T : Event> Any.listen(
             priority: Int = 0,
             alwaysListen: Boolean = false,
             noinline function: SafeContext.(T) -> Unit = {},
@@ -142,7 +144,7 @@ class SafeListener<T : Event>(
          *
          * Usage:
          * ```kotlin
-         * private val event by listenNext<MyEvent> { event ->
+         * private val event by listenOnce<MyEvent> { event ->
          *     player.sendMessage("Event received only once: $event")
          *     // event is stored in the value
          *     // event is unsubscribed after execution
@@ -193,11 +195,11 @@ class SafeListener<T : Event>(
          *
          * Usage:
          * ```kotlin
-         * myTask.listener<MyEvent> { event ->
+         * myTask.listen<MyEvent> { event ->
          *     player.sendMessage("Event received: $event")
          * }
          *
-         * myTask.listener<MyEvent>(priority = 1) { event ->
+         * myTask.listen<MyEvent>(priority = 1) { event ->
          *     player.sendMessage("Event received before the previous listener: $event")
          * }
          * ```
@@ -212,7 +214,7 @@ class SafeListener<T : Event>(
          * This function should take a SafeContext and an event of type T as parameters.
          * @return The newly created and registered [SafeListener].
          */
-        inline fun <reified T : Event> Task<*>.listener(
+        inline fun <reified T : Event> Task<*>.listen(
             priority: Int = 0,
             alwaysListen: Boolean = false,
             noinline function: SafeContext.(T) -> Unit = {},
@@ -236,12 +238,12 @@ class SafeListener<T : Event>(
          *
          * Usage:
          * ```kotlin
-         * concurrentListener<MyEvent> { event ->
+         * listenConcurrently<MyEvent> { event ->
          *     println("Concurrent event received: $event")
          *     // no safe access to player or world
          * }
          *
-         * concurrentListener<MyEvent>(priority = 1) { event ->
+         * listenConcurrently<MyEvent>(priority = 1) { event ->
          *     println("Concurrent event received before the previous listener: $event")
          * }
          * ```
@@ -251,13 +253,14 @@ class SafeListener<T : Event>(
          * @param function The function to be executed when the event is posted. This function should take a SafeContext and an event of type T as parameters.
          * @return The newly created and registered [SafeListener].
          */
-        inline fun <reified T : Event> Any.concurrentListener(
+        inline fun <reified T : Event> Any.listenConcurrently(
             priority: Int = 0,
             alwaysListen: Boolean = false,
+            scheduler: CoroutineDispatcher = Dispatchers.Default,
             noinline function: suspend SafeContext.(T) -> Unit = {},
         ): SafeListener<T> {
             val listener = SafeListener<T>(priority, this, alwaysListen) { event ->
-                runConcurrent {
+                runConcurrent(scheduler) {
                     function(event)
                 }
             }

--- a/common/src/main/kotlin/com/lambda/event/listener/SafeListener.kt
+++ b/common/src/main/kotlin/com/lambda/event/listener/SafeListener.kt
@@ -121,9 +121,56 @@ class SafeListener<T : Event>(
             alwaysListen: Boolean = false,
             noinline function: SafeContext.(T) -> Unit = {},
         ): SafeListener<T> {
-            val listener = SafeListener<T>(priority, this, alwaysListen) { event -> function(event) }
+            val listener = SafeListener<T>(priority, this, alwaysListen) { event ->
+                function(event)
+            }
 
             EventFlow.syncListeners.subscribe(listener)
+
+            return listener
+        }
+
+        /**
+         * Registers a new [SafeListener] for a generic [Event] type [T] within the context of a [Task].
+         * The [function] is executed on the same thread where the [Event] was dispatched.
+         * The [function] will only be executed when the context satisfies certain safety conditions.
+         * These conditions are met when none of the following [SafeContext] properties are null:
+         * - [SafeContext.world]
+         * - [SafeContext.player]
+         * - [SafeContext.interaction]
+         * - [SafeContext.connection]
+         *
+         * Usage:
+         * ```kotlin
+         * myTask.listen<MyEvent> { event ->
+         *     player.sendMessage("Event received: $event")
+         * }
+         *
+         * myTask.listen<MyEvent>(priority = 1) { event ->
+         *     player.sendMessage("Event received before the previous listener: $event")
+         * }
+         * ```
+         *
+         * @param T The type of the event to listen for.
+         * This should be a subclass of Event.
+         * @param priority The priority of the listener.
+         * Listeners with higher priority will be executed first.
+         * The Default value is 0.
+         * @param alwaysListen If true, the listener will be executed even if it is muted. The Default value is false.
+         * @param function The function to be executed when the event is posted.
+         * This function should take a SafeContext and an event of type T as parameters.
+         * @return The newly created and registered [SafeListener].
+         */
+        inline fun <reified T : Event> Task<*>.listen(
+            priority: Int = 0,
+            alwaysListen: Boolean = false,
+            noinline function: SafeContext.(T) -> Unit = {},
+        ): SafeListener<T> {
+            val listener = SafeListener<T>(priority, this, alwaysListen) { event ->
+                function(event) // ToDo: run function always on game thread
+            }
+
+            syncListeners.subscribe<T>(listener)
 
             return listener
         }
@@ -181,51 +228,6 @@ class SafeListener<T : Event>(
             EventFlow.syncListeners.subscribe<T>(destroyable)
 
             return pointer
-        }
-
-        /**
-         * Registers a new [SafeListener] for a generic [Event] type [T] within the context of a [Task].
-         * The [function] is executed on the same thread where the [Event] was dispatched.
-         * The [function] will only be executed when the context satisfies certain safety conditions.
-         * These conditions are met when none of the following [SafeContext] properties are null:
-         * - [SafeContext.world]
-         * - [SafeContext.player]
-         * - [SafeContext.interaction]
-         * - [SafeContext.connection]
-         *
-         * Usage:
-         * ```kotlin
-         * myTask.listen<MyEvent> { event ->
-         *     player.sendMessage("Event received: $event")
-         * }
-         *
-         * myTask.listen<MyEvent>(priority = 1) { event ->
-         *     player.sendMessage("Event received before the previous listener: $event")
-         * }
-         * ```
-         *
-         * @param T The type of the event to listen for.
-         * This should be a subclass of Event.
-         * @param priority The priority of the listener.
-         * Listeners with higher priority will be executed first.
-         * The Default value is 0.
-         * @param alwaysListen If true, the listener will be executed even if it is muted. The Default value is false.
-         * @param function The function to be executed when the event is posted.
-         * This function should take a SafeContext and an event of type T as parameters.
-         * @return The newly created and registered [SafeListener].
-         */
-        inline fun <reified T : Event> Task<*>.listen(
-            priority: Int = 0,
-            alwaysListen: Boolean = false,
-            noinline function: SafeContext.(T) -> Unit = {},
-        ): SafeListener<T> {
-            val listener = SafeListener<T>(priority, this, alwaysListen) { event ->
-                function(event) // ToDo: run function always on game thread
-            }
-
-            syncListeners.subscribe<T>(listener)
-
-            return listener
         }
 
         /**

--- a/common/src/main/kotlin/com/lambda/event/listener/UnsafeListener.kt
+++ b/common/src/main/kotlin/com/lambda/event/listener/UnsafeListener.kt
@@ -81,16 +81,16 @@ class UnsafeListener<T : Event>(
          * The [function] is executed on the same thread where the [Event] was dispatched.
          * The execution of the [function] is independent of the safety conditions of the context.
          * Use this function when you need to listen to an [Event] in a context that is not in-game.
-         * For only in-game related contexts, use the [SafeListener.listener] function instead.
+         * For only in-game related contexts, use the [SafeListener.listen] function instead.
          *
          * Usage:
          * ```kotlin
-         * unsafeListener<MyEvent> { event ->
+         * listenUnsafe<MyEvent> { event ->
          *     println("Unsafe event received: $event")
          *     // no safe access to player or world
          * }
          *
-         * unsafeListener<MyEvent>(priority = 1) { event ->
+         * listenUnsafe<MyEvent>(priority = 1) { event ->
          *     println("Unsafe event received before the previous listener: $event")
          * }
          * ```
@@ -101,7 +101,7 @@ class UnsafeListener<T : Event>(
          * @param function The function to be executed when the event is posted. This function should take an event of type T as a parameter.
          * @return The newly created and registered [UnsafeListener].
          */
-        inline fun <reified T : Event> Any.unsafeListener(
+        inline fun <reified T : Event> Any.listenUnsafe(
             priority: Int = 0,
             alwaysListen: Boolean = false,
             noinline function: (T) -> Unit = {},
@@ -123,7 +123,7 @@ class UnsafeListener<T : Event>(
          *
          * Usage:
          * ```kotlin
-         * private val event by unsafeListenOnce<MyEvent> { event ->
+         * private val event by listenUnsafeOnce<MyEvent> { event ->
          *     println("Unsafe event received only once: $event")
          *     // no safe access to player or world
          *     // event is stored in the value
@@ -139,7 +139,7 @@ class UnsafeListener<T : Event>(
          * @param transform The function used to transform the event into a value.
          * @return The newly created and registered [UnsafeListener].
          */
-        inline fun <reified T : Event, reified E> Any.unsafeListenOnce(
+        inline fun <reified T : Event, reified E> Any.listenUnsafeOnce(
             priority: Int = 0,
             alwaysListen: Boolean = false,
             noinline transform: (T) -> E? = { null },
@@ -148,7 +148,7 @@ class UnsafeListener<T : Event>(
             val pointer = Pointer<E>()
 
             val destroyable by selfReference<UnsafeListener<T>> {
-                UnsafeListener(priority, this@unsafeListenOnce, alwaysListen) { event ->
+                UnsafeListener(priority, this@listenUnsafeOnce, alwaysListen) { event ->
                     pointer.value = transform(event)
 
                     if (predicate(event) &&
@@ -169,19 +169,19 @@ class UnsafeListener<T : Event>(
          * Registers a new [UnsafeListener] for a generic [Event] type [T].
          * The [function] is executed on a new thread running asynchronously to the game thread.
          * This function should only be used when the [function] performs read actions on the game data.
-         * For only in-game related contexts, use the [SafeListener.concurrentListener] function instead.
+         * For only in-game related contexts, use the [SafeListener.listenConcurrently] function instead.
          *
          * Caution: Using this function to write to the game data can lead to race conditions. Therefore, it is recommended
          * to use this function only for read operations to avoid potential concurrency issues.
          *
          * Usage:
          * ```kotlin
-         * concurrentListener<MyEvent> { event ->
+         * listenUnsafeConcurrently<MyEvent> { event ->
          *     println("Concurrent event received: $event")
          *     // no safe access to player or world
          * }
          *
-         * concurrentListener<MyEvent>(priority = 1) { event ->
+         * listenUnsafeConcurrently<MyEvent>(priority = 1) { event ->
          *     println("Concurrent event received before the previous listener: $event")
          * }
          * ```
@@ -191,7 +191,7 @@ class UnsafeListener<T : Event>(
          * @param function The function to be executed when the event is posted. This function should take a SafeContext and an event of type T as parameters.
          * @return The newly created and registered [UnsafeListener].
          */
-        inline fun <reified T : Event> Any.unsafeConcurrentListener(
+        inline fun <reified T : Event> Any.listenUnsafeConcurrently(
             priority: Int = 0,
             alwaysListen: Boolean = false,
             noinline function: (T) -> Unit = {},

--- a/common/src/main/kotlin/com/lambda/event/listener/UnsafeListener.kt
+++ b/common/src/main/kotlin/com/lambda/event/listener/UnsafeListener.kt
@@ -123,7 +123,7 @@ class UnsafeListener<T : Event>(
          *
          * Usage:
          * ```kotlin
-         * private val event by listenUnsafeOnce<MyEvent> { event ->
+         * private val event by listenOnceUnsafe<MyEvent> { event ->
          *     println("Unsafe event received only once: $event")
          *     // no safe access to player or world
          *     // event is stored in the value
@@ -139,7 +139,7 @@ class UnsafeListener<T : Event>(
          * @param transform The function used to transform the event into a value.
          * @return The newly created and registered [UnsafeListener].
          */
-        inline fun <reified T : Event, reified E> Any.listenUnsafeOnce(
+        inline fun <reified T : Event, reified E> Any.listenOnceUnsafe(
             priority: Int = 0,
             alwaysListen: Boolean = false,
             noinline transform: (T) -> E? = { null },
@@ -148,7 +148,7 @@ class UnsafeListener<T : Event>(
             val pointer = Pointer<E>()
 
             val destroyable by selfReference<UnsafeListener<T>> {
-                UnsafeListener(priority, this@listenUnsafeOnce, alwaysListen) { event ->
+                UnsafeListener(priority, this@listenOnceUnsafe, alwaysListen) { event ->
                     pointer.value = transform(event)
 
                     if (predicate(event) &&
@@ -196,7 +196,9 @@ class UnsafeListener<T : Event>(
             alwaysListen: Boolean = false,
             noinline function: (T) -> Unit = {},
         ): UnsafeListener<T> {
-            val listener = UnsafeListener<T>(priority, this, alwaysListen) { event -> function(event) }
+            val listener = UnsafeListener<T>(priority, this, alwaysListen) { event ->
+                function(event)
+            }
 
             EventFlow.concurrentListeners.subscribe<T>(listener)
 

--- a/common/src/main/kotlin/com/lambda/graphics/RenderMain.kt
+++ b/common/src/main/kotlin/com/lambda/graphics/RenderMain.kt
@@ -21,7 +21,7 @@ import com.lambda.Lambda.mc
 import com.lambda.event.EventFlow.post
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.animation.Animation.Companion.exp
 import com.lambda.graphics.animation.AnimationTicker
 import com.lambda.graphics.buffer.FrameBuffer
@@ -46,7 +46,7 @@ object RenderMain {
     private val showHud get() = mc.currentScreen == null || LambdaHudGui.isOpen
 
     private val hudAnimation0 = with(AnimationTicker()) {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             tick()
         }
 

--- a/common/src/main/kotlin/com/lambda/graphics/renderer/esp/ChunkedESP.kt
+++ b/common/src/main/kotlin/com/lambda/graphics/renderer/esp/ChunkedESP.kt
@@ -20,8 +20,8 @@ package com.lambda.graphics.renderer.esp
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
 import com.lambda.event.events.WorldEvent
-import com.lambda.event.listener.SafeListener.Companion.concurrentListener
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listenConcurrently
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.impl.ESPRenderer
 import com.lambda.graphics.renderer.esp.impl.StaticESPRenderer
 import com.lambda.module.modules.client.RenderSettings
@@ -53,19 +53,19 @@ class ChunkedESP private constructor(
     }
 
     init {
-        concurrentListener<WorldEvent.BlockUpdate> { event ->
+        listenConcurrently<WorldEvent.BlockUpdate> { event ->
             world.getWorldChunk(event.pos).renderer.notifyChunks()
         }
 
-        concurrentListener<WorldEvent.ChunkEvent.Load> { event ->
+        listenConcurrently<WorldEvent.ChunkEvent.Load> { event ->
             event.chunk.renderer.notifyChunks()
         }
 
-        concurrentListener<WorldEvent.ChunkEvent.Unload> { event ->
+        listenConcurrently<WorldEvent.ChunkEvent.Unload> { event ->
             rendererMap.remove(event.chunk.pos.toLong())?.notifyChunks()
         }
 
-        owner.concurrentListener<TickEvent.Pre> {
+        owner.listenConcurrently<TickEvent.Pre> {
             if (++ticks % RenderSettings.updateFrequency == 0) {
                 val polls = minOf(RenderSettings.rebuildsPerTick, rebuildQueue.size)
 
@@ -76,8 +76,8 @@ class ChunkedESP private constructor(
             }
         }
 
-        owner.listener<TickEvent.Pre> {
-            if (uploadQueue.isEmpty()) return@listener
+        owner.listen<TickEvent.Pre> {
+            if (uploadQueue.isEmpty()) return@listen
 
             val polls = minOf(RenderSettings.uploadsPerTick, uploadQueue.size)
 
@@ -86,7 +86,7 @@ class ChunkedESP private constructor(
             }
         }
 
-        owner.listener<RenderEvent.World> {
+        owner.listen<RenderEvent.World> {
             rendererMap.values.forEach {
                 it.renderer?.render()
             }

--- a/common/src/main/kotlin/com/lambda/graphics/renderer/esp/global/DynamicESP.kt
+++ b/common/src/main/kotlin/com/lambda/graphics/renderer/esp/global/DynamicESP.kt
@@ -20,12 +20,12 @@ package com.lambda.graphics.renderer.esp.global
 import com.lambda.event.EventFlow.post
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.impl.DynamicESPRenderer
 
 object DynamicESP : DynamicESPRenderer() {
     init {
-        listener<TickEvent.Post> {
+        listen<TickEvent.Post> {
             clear()
             RenderEvent.DynamicESP().post()
             upload()

--- a/common/src/main/kotlin/com/lambda/graphics/renderer/esp/global/StaticESP.kt
+++ b/common/src/main/kotlin/com/lambda/graphics/renderer/esp/global/StaticESP.kt
@@ -20,12 +20,12 @@ package com.lambda.graphics.renderer.esp.global
 import com.lambda.event.EventFlow.post
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.impl.StaticESPRenderer
 
 object StaticESP : StaticESPRenderer(false) {
     init {
-        listener<TickEvent.Post> {
+        listen<TickEvent.Post> {
             clear()
             RenderEvent.StaticESP().post()
             upload()

--- a/common/src/main/kotlin/com/lambda/gui/api/LambdaGui.kt
+++ b/common/src/main/kotlin/com/lambda/gui/api/LambdaGui.kt
@@ -21,7 +21,7 @@ import com.lambda.Lambda.mc
 import com.lambda.event.Muteable
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.animation.AnimationTicker
 import com.lambda.gui.api.component.core.IComponent
 import com.lambda.gui.impl.AbstractClickGui
@@ -51,12 +51,12 @@ abstract class LambdaGui(
     val animation = AnimationTicker()
 
     init {
-        listener<RenderEvent.GUI.Scaled> { event ->
+        listen<RenderEvent.GUI.Scaled> { event ->
             screenSize = event.screenSize
             onEvent(GuiEvent.Render())
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             animation.tick()
             onEvent(GuiEvent.Tick())
         }

--- a/common/src/main/kotlin/com/lambda/interaction/RotationManager.kt
+++ b/common/src/main/kotlin/com/lambda/interaction/RotationManager.kt
@@ -23,8 +23,8 @@ import com.lambda.context.SafeContext
 import com.lambda.core.Loadable
 import com.lambda.event.EventFlow.post
 import com.lambda.event.events.*
-import com.lambda.event.listener.SafeListener.Companion.listener
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeListener
+import com.lambda.event.listener.SafeListener.Companion.listen
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.interaction.rotation.Rotation
 import com.lambda.interaction.rotation.Rotation.Companion.angleDifference
 import com.lambda.interaction.rotation.Rotation.Companion.fixSensitivity
@@ -60,7 +60,7 @@ object RotationManager : Loadable {
     ) {
         var lastCtx: RotationContext? = null
 
-        this.listener<RotationEvent.Update>(priority, alwaysListen) { event ->
+        this.listen<RotationEvent.Update>(priority, alwaysListen) { event ->
             val rotationContext = onUpdate(event.context)
 
             rotationContext?.let {
@@ -70,7 +70,7 @@ object RotationManager : Loadable {
             lastCtx = rotationContext
         }
 
-        this.listener<RotationEvent.Post> { event ->
+        this.listen<RotationEvent.Post> { event ->
             if (event.context == lastCtx && event.context.isValid) {
                 onReceive()
             }
@@ -89,16 +89,16 @@ object RotationManager : Loadable {
     }
 
     init {
-        listener<PacketEvent.Send.Post> { event ->
+        listen<PacketEvent.Send.Post> { event ->
             val packet = event.packet
-            if (packet !is PlayerPositionLookS2CPacket) return@listener
+            if (packet !is PlayerPositionLookS2CPacket) return@listen
 
             runGameScheduled {
                 reset(Rotation(packet.yaw, packet.pitch))
             }
         }
 
-        unsafeListener<ConnectionEvent.Disconnect> {
+        listenUnsafe<ConnectionEvent.Disconnect> {
             reset(Rotation.ZERO)
         }
     }

--- a/common/src/main/kotlin/com/lambda/interaction/material/ContainerManager.kt
+++ b/common/src/main/kotlin/com/lambda/interaction/material/ContainerManager.kt
@@ -20,7 +20,7 @@ package com.lambda.interaction.material
 import com.lambda.core.Loadable
 import com.lambda.event.events.PlayerEvent
 import com.lambda.event.events.ScreenHandlerEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.material.StackSelection.Companion.select
 import com.lambda.interaction.material.container.*
 import com.lambda.module.modules.client.TaskFlow
@@ -51,18 +51,18 @@ object ContainerManager : Loadable {
     private var lastInteractedBlockEntity: BlockEntity? = null
 
     init {
-        listener<PlayerEvent.Interact.Block> {
+        listen<PlayerEvent.Interact.Block> {
             lastInteractedBlockEntity = it.blockHitResult.blockPos.blockEntity(world)
         }
 
-        listener<ScreenHandlerEvent.Close> { event ->
-            if (event.screenHandler !is GenericContainerScreenHandler) return@listener
+        listen<ScreenHandlerEvent.Close> { event ->
+            if (event.screenHandler !is GenericContainerScreenHandler) return@listen
 
             val handler = event.screenHandler
 
             when (val block = lastInteractedBlockEntity) {
                 is EnderChestBlockEntity -> {
-                    if (handler.type != ScreenHandlerType.GENERIC_9X3) return@listener
+                    if (handler.type != ScreenHandlerType.GENERIC_9X3) return@listen
 
                     this@ContainerManager.info("Updating EnderChestContainer")
                     EnderChestContainer.update(handler.containerStacks)
@@ -70,7 +70,7 @@ object ContainerManager : Loadable {
 
                 is ChestBlockEntity -> {
                     // ToDo: Handle double chests and single chests
-                    if (handler.type != ScreenHandlerType.GENERIC_9X6) return@listener
+                    if (handler.type != ScreenHandlerType.GENERIC_9X6) return@listen
                     val stacks = handler.containerStacks
 
                     this@ContainerManager.info("Updating ChestContainer")

--- a/common/src/main/kotlin/com/lambda/module/HudModule.kt
+++ b/common/src/main/kotlin/com/lambda/module/HudModule.kt
@@ -19,9 +19,8 @@ package com.lambda.module
 
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.animation.AnimationTicker
-import com.lambda.gui.api.GuiEvent
 import com.lambda.gui.api.RenderLayer
 import com.lambda.gui.api.component.core.DockingRect
 import com.lambda.module.tag.ModuleTag
@@ -84,7 +83,7 @@ abstract class HudModule(
         renderCallables.add(block)
 
     init {
-        listener<RenderEvent.GUI.HUD> { event ->
+        listen<RenderEvent.GUI.HUD> { event ->
             rectHandler.screenSize = event.screenSize
 
             renderCallables.forEach { function ->
@@ -94,7 +93,7 @@ abstract class HudModule(
             renderer.render()
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             animation.tick()
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/Module.kt
+++ b/common/src/main/kotlin/com/lambda/module/Module.kt
@@ -29,7 +29,7 @@ import com.lambda.event.Muteable
 import com.lambda.event.events.KeyboardEvent
 import com.lambda.event.listener.Listener
 import com.lambda.event.listener.SafeListener
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.event.listener.UnsafeListener
 import com.lambda.gui.impl.clickgui.buttons.ModuleButton
 import com.lambda.module.modules.client.ClickGui
@@ -38,7 +38,6 @@ import com.lambda.sound.LambdaSound
 import com.lambda.sound.SoundManager.playSoundRandomly
 import com.lambda.util.KeyCode
 import com.lambda.util.Nameable
-import net.minecraft.client.gui.screen.ChatScreen
 
 /**
  * A [Module] is a feature or tool for the utility mod.
@@ -128,11 +127,11 @@ abstract class Module(
     val keybind by keybindSetting
 
     init {
-        listener<KeyboardEvent.Press>(alwaysListen = true) { event ->
-            if (mc.options.commandKey.isPressed) return@listener
-            if (keybind == KeyCode.UNBOUND) return@listener
-            if (event.translated != keybind) return@listener
-            if (mc.currentScreen != null) return@listener
+        listen<KeyboardEvent.Press>(alwaysListen = true) { event ->
+            if (mc.options.commandKey.isPressed) return@listen
+            if (keybind == KeyCode.UNBOUND) return@listen
+            if (event.translated != keybind) return@listen
+            if (mc.currentScreen != null) return@listen
 
             toggle()
         }

--- a/common/src/main/kotlin/com/lambda/module/modules/client/ClickGui.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/client/ClickGui.kt
@@ -19,8 +19,8 @@ package com.lambda.module.modules.client
 
 import com.lambda.event.events.ClientEvent
 import com.lambda.event.events.KeyboardEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeListener
+import com.lambda.event.listener.SafeListener.Companion.listen
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.gui.impl.clickgui.LambdaClickGui
 import com.lambda.gui.impl.hudgui.LambdaHudGui
 import com.lambda.module.Module
@@ -62,15 +62,15 @@ object ClickGui : Module(
             LambdaHudGui.close()
         }
 
-        listener<KeyboardEvent.Press>(priority = Int.MAX_VALUE) { event ->
-            if (mc.options.commandKey.isPressed) return@listener
-            if (keybind == KeyCode.UNBOUND) return@listener
-            if (event.translated != keybind) return@listener
+        listen<KeyboardEvent.Press>(priority = Int.MAX_VALUE) { event ->
+            if (mc.options.commandKey.isPressed) return@listen
+            if (keybind == KeyCode.UNBOUND) return@listen
+            if (event.translated != keybind) return@listen
             // ToDo: Exception for ui text input
             toggle()
         }
 
-        unsafeListener<ClientEvent.Shutdown> {
+        listenUnsafe<ClientEvent.Shutdown> {
             disable()
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/client/DiscordRPC.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/client/DiscordRPC.kt
@@ -22,7 +22,7 @@ import com.lambda.Lambda.LOG
 import com.lambda.Lambda.mc
 import com.lambda.event.EventFlow
 import com.lambda.event.events.ConnectionEvent
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeListener
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.http.api.rpc.v1.endpoints.*
 import com.lambda.http.api.rpc.v1.models.Authentication
 import com.lambda.http.api.rpc.v1.models.Party
@@ -96,19 +96,19 @@ object DiscordRPC : Module(
         get() = currentParty?.players?.any { it.uuid == this@isInParty.uuid }
 
     init {
-        unsafeListener<ConnectionEvent.Connect.Login.EncryptionRequest> {
+        listenUnsafe<ConnectionEvent.Connect.Login.EncryptionRequest> {
             connectionTime = System.currentTimeMillis()
             serverId = it.serverId
         }
 
-        unsafeListener<ConnectionEvent.Connect.Login.EncryptionResponse> {
+        listenUnsafe<ConnectionEvent.Connect.Login.EncryptionResponse> {
             if (it.secretKey.isDestroyed)
-                return@unsafeListener logError("Error during the login process", "The client secret key was destroyed by another listener")
+                return@listenUnsafe logError("Error during the login process", "The client secret key was destroyed by another listener")
 
             keyEvent = it
         }
 
-        unsafeListener<ConnectionEvent.Connect.Post> { connect() }
+        listenUnsafe<ConnectionEvent.Connect.Post> { connect() }
 
         // TODO: Exponential backoff up to 25 seconds
         onEnable { connect() }

--- a/common/src/main/kotlin/com/lambda/module/modules/client/GuiSettings.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/client/GuiSettings.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.client
 
 import com.lambda.event.events.ConnectionEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeListener
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.graphics.animation.Animation.Companion.exp
 import com.lambda.graphics.animation.AnimationTicker
 import com.lambda.gui.impl.clickgui.LambdaClickGui
@@ -69,12 +69,12 @@ object GuiSettings : Module(
         }
 
     private val animation = with(AnimationTicker()) {
-        unsafeListener<TickEvent.Pre>(alwaysListen = true) {
+        listenUnsafe<TickEvent.Pre>(alwaysListen = true) {
             tick()
         }
 
         exp({ targetScale }, 0.5).apply {
-            unsafeListener<ConnectionEvent.Connect.Pre>(alwaysListen = true) {
+            listenUnsafe<ConnectionEvent.Connect.Pre>(alwaysListen = true) {
                 setValue(targetScale)
             }
         }

--- a/common/src/main/kotlin/com/lambda/module/modules/client/LambdaMoji.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/client/LambdaMoji.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.client
 
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.gui.api.RenderLayer
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
@@ -37,7 +37,7 @@ object LambdaMoji : Module(
     private val renderQueue = hashMapOf<List<String>, List<Vec2d>>()
 
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             var index = 0
             renderQueue.forEach { (emojis, positions) ->
                 emojis.forEachIndexed { emojiIndex, emoji ->
@@ -54,7 +54,7 @@ object LambdaMoji : Module(
             }
         }
 
-        listener<RenderEvent.GUI.Fixed> {
+        listen<RenderEvent.GUI.Fixed> {
             renderer.render()
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/combat/Criticals.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/combat/Criticals.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.combat
 
 import com.lambda.context.SafeContext
 import com.lambda.event.events.PlayerEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.rotation.Rotation
 import com.lambda.interaction.rotation.Rotation.Companion.rotationTo
 import com.lambda.module.Module
@@ -47,7 +47,7 @@ object Criticals : Module(
     }
 
     init {
-        listener<PlayerEvent.Attack.Entity> {
+        listen<PlayerEvent.Attack.Entity> {
             when (mode) {
                 Mode.Grim -> {
                     if (player.isOnGround) posPacket(0.00000001, rotation = player.rotation)

--- a/common/src/main/kotlin/com/lambda/module/modules/combat/CrystalAura.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/combat/CrystalAura.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.combat
 import com.lambda.config.groups.InteractionSettings
 import com.lambda.config.groups.RotationSettings
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.concurrentListener
+import com.lambda.event.listener.SafeListener.Companion.listenConcurrently
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import net.minecraft.util.Hand
@@ -65,7 +65,7 @@ object CrystalAura : Module(
     }
 
     init {
-        concurrentListener<TickEvent.Pre> {}
+        listenConcurrently<TickEvent.Pre> {}
 
         /*listener<RotationEvent.Pre> { event ->
             event.lookAtEntity(rotation, interac, getClosestEntity<LivingEntity>(player.eyePos, placeRange) ?: return@listener)

--- a/common/src/main/kotlin/com/lambda/module/modules/combat/KillAura.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/combat/KillAura.kt
@@ -24,7 +24,7 @@ import com.lambda.context.SafeContext
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.PlayerPacketEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.RotationManager
 import com.lambda.interaction.RotationManager.requestRotation
 import com.lambda.interaction.rotation.Rotation
@@ -123,13 +123,13 @@ object KillAura : Module(
             }
         )
 
-        listener<PlayerPacketEvent.Pre>(Int.MIN_VALUE) { event ->
+        listen<PlayerPacketEvent.Pre>(Int.MIN_VALUE) { event ->
             prevY = lastY
             lastY = event.position.y
             lastOnGround = event.onGround
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             target = targeting.target()
             if (!timerSync) attackTicks++
 
@@ -148,11 +148,11 @@ object KillAura : Module(
             }
         }
 
-        listener<PacketEvent.Send.Post> { event ->
+        listen<PacketEvent.Send.Post> { event ->
             if (event.packet !is HandSwingC2SPacket &&
                 event.packet !is UpdateSelectedSlotC2SPacket &&
                 event.packet !is PlayerInteractEntityC2SPacket
-            ) return@listener
+            ) return@listen
 
             attackTicks = 0
         }

--- a/common/src/main/kotlin/com/lambda/module/modules/debug/BaritoneTest.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/debug/BaritoneTest.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.debug
 import baritone.api.BaritoneAPI
 import baritone.api.pathing.goals.GoalXZ
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 
@@ -30,7 +30,7 @@ object BaritoneTest : Module(
     defaultTags = setOf(ModuleTag.DEBUG)
 ) {
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.setGoalAndPath(GoalXZ(0, 0))
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/debug/BlockTest.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/debug/BlockTest.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.debug
 
 import com.lambda.event.events.RenderEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.builders.build
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
@@ -49,7 +49,7 @@ object BlockTest : Module(
     private val outlineColor = Color(100, 150, 255, 51)
 
     init {
-        listener<RenderEvent.StaticESP> {
+        listen<RenderEvent.StaticESP> {
             blockSearch(range, step) { _, state ->
                 state.isOf(Blocks.DIAMOND_BLOCK)
             }.forEach { (pos, state) ->

--- a/common/src/main/kotlin/com/lambda/module/modules/debug/ContainerTest.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/debug/ContainerTest.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.debug
 
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.material.StackSelection.Companion.select
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
@@ -31,7 +31,7 @@ object ContainerTest : Module(
     defaultTags = setOf(ModuleTag.DEBUG)
 ) {
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
 //            info(task.info)
         }
 

--- a/common/src/main/kotlin/com/lambda/module/modules/debug/InventoryDebug.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/debug/InventoryDebug.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.debug
 import com.lambda.Lambda.LOG
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.ScreenHandlerEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.util.Communication.info
@@ -35,19 +35,19 @@ object InventoryDebug : Module(
     defaultTags = setOf(ModuleTag.DEBUG)
 ) {
     init {
-        listener<ScreenHandlerEvent.Open> {
+        listen<ScreenHandlerEvent.Open> {
             info("Opened screen handler: ${it.screenHandler::class.simpleName}")
         }
 
-        listener<ScreenHandlerEvent.Close> {
+        listen<ScreenHandlerEvent.Close> {
             info("Closed screen handler: ${it.screenHandler::class.simpleName}")
         }
 
-        listener<ScreenHandlerEvent.Update> {
+        listen<ScreenHandlerEvent.Update> {
             info("Updated screen handler: ${it.revision}, ${it.stacks}, ${it.cursorStack}")
         }
 
-        listener<PacketEvent.Receive.Pre> {
+        listen<PacketEvent.Receive.Pre> {
             when (val packet = it.packet) {
                 is UpdateSelectedSlotS2CPacket, is InventoryS2CPacket -> {
                     this@InventoryDebug.info(packet.dynamicString())
@@ -55,7 +55,7 @@ object InventoryDebug : Module(
             }
         }
 
-        listener<PacketEvent.Send.Pre> {
+        listen<PacketEvent.Send.Pre> {
             when (it.packet) {
                 is SlotChangedStateC2SPacket,
                 is ClickSlotC2SPacket,

--- a/common/src/main/kotlin/com/lambda/module/modules/debug/RenderTest.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/debug/RenderTest.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.debug
 
 import com.lambda.event.events.RenderEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.DynamicAABB.Companion.dynamicBox
 import com.lambda.graphics.renderer.esp.builders.build
 import com.lambda.module.Module
@@ -45,14 +45,14 @@ object RenderTest : Module(
     private val filledColor = outlineColor.setAlpha(0.2)
 
     init {
-        listener<RenderEvent.DynamicESP> {
+        listen<RenderEvent.DynamicESP> {
             entitySearch<LivingEntity>(8.0)
                 .forEach { entity ->
                     it.renderer.build(entity.dynamicBox, filledColor, outlineColor)
                 }
         }
 
-        listener<RenderEvent.StaticESP> {
+        listen<RenderEvent.StaticESP> {
             it.renderer.build(Box.of(player.pos, 0.3, 0.3, 0.3), filledColor, outlineColor)
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/BackTrack.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/BackTrack.kt
@@ -22,7 +22,7 @@ import com.lambda.event.events.ConnectionEvent
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.DynamicAABB
 import com.lambda.graphics.renderer.esp.builders.build
 import com.lambda.module.Module
@@ -92,7 +92,7 @@ object BackTrack : Module(
     }
 
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             val prevTarget = target
             target = if (KillAura.isDisabled) null else KillAura.target
             val currentTarget = target
@@ -101,7 +101,7 @@ object BackTrack : Module(
                 poolPackets(true)
                 targetPos = null
                 box.reset()
-                return@listener
+                return@listen
             }
 
             val pos = targetPos ?: currentTarget.pos
@@ -111,8 +111,8 @@ object BackTrack : Module(
             poolPackets()
         }
 
-        listener<RenderEvent.DynamicESP> {
-            val target = target ?: return@listener
+        listen<RenderEvent.DynamicESP> {
+            val target = target ?: return@listen
 
             val c1 = GuiSettings.primaryColor
             val c2 = Color.RED
@@ -122,14 +122,14 @@ object BackTrack : Module(
             it.renderer.build(box, c.multAlpha(0.3), c.multAlpha(0.8))
         }
 
-        listener<PacketEvent.Send.Pre> { event ->
-            if (!outbound || target == null) return@listener
+        listen<PacketEvent.Send.Pre> { event ->
+            if (!outbound || target == null) return@listen
             sendPool.add(event.packet to currentTime)
             event.cancel()
         }
 
-        listener<PacketEvent.Receive.Pre> { event ->
-            val target = target ?: return@listener
+        listen<PacketEvent.Receive.Pre> { event ->
+            val target = target ?: return@listen
 
             val packet = event.packet
 
@@ -155,7 +155,7 @@ object BackTrack : Module(
                 is PlaySoundS2CPacket, is PlaySoundFromEntityS2CPacket, is StopSoundS2CPacket,
                     /*is EntityStatusS2CPacket,*/ is EntityStatusEffectS2CPacket, is EntityAnimationS2CPacket,
                 is ParticleS2CPacket, is WorldTimeUpdateS2CPacket, is WorldEventS2CPacket -> {
-                    return@listener
+                    return@listen
                 }
             }
 
@@ -163,7 +163,7 @@ object BackTrack : Module(
             event.cancel()
         }
 
-        listener<ConnectionEvent.Connect.Pre> {
+        listen<ConnectionEvent.Connect.Pre> {
             receivePool.clear()
             sendPool.clear()
         }

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/Blink.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/Blink.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.movement
 import com.lambda.context.SafeContext
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.RenderEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.DynamicAABB
 import com.lambda.graphics.renderer.esp.builders.build
 import com.lambda.module.Module
@@ -58,47 +58,47 @@ object Blink : Module(
     private var lastBox = Box(BlockPos.ORIGIN)
 
     init {
-        listener<RenderEvent.World> {
+        listen<RenderEvent.World> {
             val time = System.currentTimeMillis()
 
-            if (isActive && time - lastUpdate < delay) return@listener
+            if (isActive && time - lastUpdate < delay) return@listen
             lastUpdate = time
 
             poolPackets()
         }
 
-        listener<RenderEvent.DynamicESP> { event ->
+        listen<RenderEvent.DynamicESP> { event ->
             val color = GuiSettings.primaryColor
             event.renderer.build(box.update(lastBox), color.setAlpha(0.3), color)
         }
 
-        listener<PacketEvent.Send.Pre> { event ->
-            if (!isActive) return@listener
+        listen<PacketEvent.Send.Pre> { event ->
+            if (!isActive) return@listen
 
             packetPool.add(event.packet)
             event.cancel()
-            return@listener
+            return@listen
         }
 
-        listener<PacketEvent.Send.Post> { event ->
+        listen<PacketEvent.Send.Post> { event ->
             val packet = event.packet
-            if (packet !is PlayerMoveC2SPacket) return@listener
+            if (packet !is PlayerMoveC2SPacket) return@listen
 
             val vec = Vec3d(packet.getX(0.0), packet.getY(0.0), packet.getZ(0.0))
-            if (vec == Vec3d.ZERO) return@listener
+            if (vec == Vec3d.ZERO) return@listen
 
             lastBox = player.boundingBox.offset(vec - player.pos)
         }
 
-        listener<PacketEvent.Receive.Pre> { event ->
-            if (!isActive || !shiftVelocity) return@listener
+        listen<PacketEvent.Receive.Pre> { event ->
+            if (!isActive || !shiftVelocity) return@listen
 
-            if (event.packet !is EntityVelocityUpdateS2CPacket) return@listener
-            if (event.packet.id != player.id) return@listener
+            if (event.packet !is EntityVelocityUpdateS2CPacket) return@listen
+            if (event.packet.id != player.id) return@listen
 
             lastVelocity = event.packet
             event.cancel()
-            return@listener
+            return@listen
         }
 
         onDisable {

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/ElytraFly.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/ElytraFly.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.movement
 
 import com.lambda.event.events.ClientEvent
 import com.lambda.event.events.MovementEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.threading.runSafe
@@ -45,15 +45,15 @@ object ElytraFly : Module(
     val doBoost: Boolean get() = isEnabled && rocketBoost
 
     init {
-        listener<MovementEvent.Player.Pre> {
+        listen<MovementEvent.Player.Pre> {
             if (playerBoost && player.isFallFlying && !player.isUsingItem) {
                 addSpeed(playerSpeed)
             }
         }
 
-        listener<ClientEvent.Sound> { event ->
-            if (!mute) return@listener
-            if (event.sound.id != SoundEvents.ITEM_ELYTRA_FLYING.id) return@listener
+        listen<ClientEvent.Sound> { event ->
+            if (!mute) return@listen
+            if (event.sound.id != SoundEvents.ITEM_ELYTRA_FLYING.id) return@listen
             event.cancel()
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/EntityControl.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/EntityControl.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.movement
 
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.util.world.fastEntitySearch
@@ -36,7 +36,7 @@ object EntityControl : Module(
     private val saddledHorses = mutableSetOf<AbstractHorseEntity>()
 
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             fastEntitySearch<AbstractHorseEntity>(8.0)
                 .forEach {
                     if (!it.isSaddled) saddledHorses.add(it)
@@ -44,13 +44,13 @@ object EntityControl : Module(
                 }
         }
 
-        listener<PacketEvent.Send.Pre> { event ->
-            if (!forceMount) return@listener
-            if (event.packet !is PlayerInteractEntityC2SPacket) return@listener
-            if (event.packet.type !is PlayerInteractEntityC2SPacket.InteractAtHandler) return@listener
+        listen<PacketEvent.Send.Pre> { event ->
+            if (!forceMount) return@listen
+            if (event.packet !is PlayerInteractEntityC2SPacket) return@listen
+            if (event.packet.type !is PlayerInteractEntityC2SPacket.InteractAtHandler) return@listen
 
-            val entity = world.getEntityById(event.packet.entityId) ?: return@listener
-            if (entity !is AbstractHorseEntity) return@listener
+            val entity = world.getEntityById(event.packet.entityId) ?: return@listen
+            if (entity !is AbstractHorseEntity) return@listen
 
             event.cancel()
         }

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/Jesus.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/Jesus.kt
@@ -22,7 +22,7 @@ import com.lambda.event.events.MovementEvent
 import com.lambda.event.events.PlayerPacketEvent
 import com.lambda.event.events.TickEvent
 import com.lambda.event.events.WorldEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.util.Nameable
@@ -62,11 +62,11 @@ object Jesus : Module(
     private var shouldWork = false
 
     init {
-        listener<PlayerPacketEvent.Pre> { event ->
-            if (!shouldWork || !waterAt(-0.0001)) return@listener
+        listen<PlayerPacketEvent.Pre> { event ->
+            if (!shouldWork || !waterAt(-0.0001)) return@listen
             event.onGround = false
 
-            if (!player.isOnGround) return@listener
+            if (!player.isOnGround) return@listen
 
             when (mode) {
                 Mode.NCP -> {
@@ -82,15 +82,15 @@ object Jesus : Module(
             }
         }
 
-        listener<MovementEvent.Player.Pre> {
-            if (!shouldWork) return@listener
+        listen<MovementEvent.Player.Pre> {
+            if (!shouldWork) return@listen
 
             goUp = waterAt(0.0001)
             val collidingWater = waterAt(-0.0001)
 
             when (mode) {
                 Mode.NCP -> {
-                    if (!collidingWater || !player.isOnGround) return@listener
+                    if (!collidingWater || !player.isOnGround) return@listen
                     setSpeed(Speed.NCP_BASE_SPEED * isInputting.toInt())
                 }
 
@@ -107,7 +107,7 @@ object Jesus : Module(
                 Mode.NCP_NEW -> {
                     if (!collidingWater) {
                         swimmingTicks = 0
-                        return@listener
+                        return@listen
                     }
 
                     if (++swimmingTicks < 15) {
@@ -115,7 +115,7 @@ object Jesus : Module(
                             setSpeed(Speed.NCP_BASE_SPEED * isInputting.toInt())
                         }
 
-                        return@listener
+                        return@listen
                     }
 
                     swimmingTicks = 0
@@ -126,20 +126,20 @@ object Jesus : Module(
             }
         }
 
-        listener<WorldEvent.Collision> { event ->
-            if (!shouldWork || goUp || !mode.collision) return@listener
+        listen<WorldEvent.Collision> { event ->
+            if (!shouldWork || goUp || !mode.collision) return@listen
 
             if (event.state.block == Blocks.WATER) {
                 event.shape = fullShape
             }
         }
 
-        listener<MovementEvent.InputUpdate> {
-            if (!shouldWork || !goUp || mode == Mode.NCP_DOLPHIN) return@listener
+        listen<MovementEvent.InputUpdate> {
+            if (!shouldWork || !goUp || mode == Mode.NCP_DOLPHIN) return@listen
             it.input.jumping = true
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             shouldWork = !player.abilities.flying && !player.isFallFlying && !player.input.sneaking
         }
 

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/NoFall.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/NoFall.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.movement
 
 import com.lambda.event.events.MovementEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.util.extension.component1
@@ -46,10 +46,10 @@ object NoFall : Module(
     }
 
     init {
-        listener<MovementEvent.Player.Post> {
+        listen<MovementEvent.Player.Post> {
             when (mode) {
                 Mode.Grim -> {
-                    if (player.fallDistance + player.motionY < 3.0) return@listener
+                    if (player.fallDistance + player.motionY < 3.0) return@listen
 
                     val (x, y, z) = player.pos
                     connection.sendPacket(PlayerMoveC2SPacket.Full(x, y + 0.0000000001, z, 0.01f, 90f, false))

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/RocketExtend.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/RocketExtend.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.movement
 
 import com.lambda.context.SafeContext
 import com.lambda.event.events.PacketEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.util.extension.filterPointer
@@ -39,7 +39,7 @@ object RocketExtend : Module(
     private val keepAliveTime by setting("Keepalive Timeout", 45, 0..60, 1, unit = " s")
 
     init {
-        listener<PacketEvent.Receive.Pre> { event ->
+        listen<PacketEvent.Receive.Pre> { event ->
             if (event.packet is PlayerPositionLookS2CPacket) reset()
 
             if (event.packet is EntitiesDestroyS2CPacket) {
@@ -50,17 +50,17 @@ object RocketExtend : Module(
             }
         }
 
-        listener<PacketEvent.Send.Pre> { event ->
-            if (event.packet !is CommonPongC2SPacket) return@listener
+        listen<PacketEvent.Send.Pre> { event ->
+            if (event.packet !is CommonPongC2SPacket) return@listen
 
             if (extendedRockets.isEmpty()) {
                 lastPingTime = System.currentTimeMillis()
-                return@listener
+                return@listen
             }
 
             if (System.currentTimeMillis() - lastPingTime > keepAliveTime * 1000) {
                 reset()
-                return@listener
+                return@listen
             }
 
             pingPacket = event.packet

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/SafeWalk.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/SafeWalk.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.movement
 
 import com.lambda.event.events.MovementEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import net.minecraft.entity.LivingEntity
@@ -33,13 +33,13 @@ object SafeWalk : Module(
     private val stepHeight by setting("Step Height", 1.1, 0.0..4.0, 0.05, unit = " blocks")
 
     init {
-        listener<MovementEvent.InputUpdate> {
+        listen<MovementEvent.InputUpdate> {
             if (sneakOnLedge && player.isOnGround && player.isNearLedge(ledgeDistance, stepHeight)) {
                 it.input.sneaking = true
             }
         }
 
-        listener<MovementEvent.ClipAtLedge> {
+        listen<MovementEvent.ClipAtLedge> {
             if (!sneakOnLedge) it.clip = true
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/Speed.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/Speed.kt
@@ -21,7 +21,7 @@ import com.lambda.config.groups.IRotationConfig
 import com.lambda.context.SafeContext
 import com.lambda.event.events.ClientEvent
 import com.lambda.event.events.MovementEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.RotationManager.requestRotation
 import com.lambda.interaction.rotation.Rotation
 import com.lambda.interaction.rotation.RotationContext
@@ -97,10 +97,10 @@ object Speed : Module(
     }
 
     init {
-        listener<MovementEvent.Player.Pre> {
+        listen<MovementEvent.Player.Pre> {
             if (!shouldWork()) {
                 reset()
-                return@listener
+                return@listen
             }
 
             when (mode) {
@@ -109,22 +109,22 @@ object Speed : Module(
             }
         }
 
-        listener<MovementEvent.Player.Post> {
+        listen<MovementEvent.Player.Post> {
             lastDistance = player.moveDelta
         }
 
-        listener<ClientEvent.Timer> {
-            if (mode != Mode.NCP_STRAFE) return@listener
-            if (!shouldWork() || !isInputting) return@listener
+        listen<ClientEvent.Timer> {
+            if (mode != Mode.NCP_STRAFE) return@listen
+            if (!shouldWork() || !isInputting) return@listen
             it.speed = ncpTimerBoost
         }
 
-        listener<MovementEvent.Jump> {
+        listen<MovementEvent.Jump> {
             if (mode == Mode.NCP_STRAFE && shouldWork()) it.cancel()
         }
 
-        listener<MovementEvent.InputUpdate>(Int.MIN_VALUE) {
-            if (mode != Mode.GRIM_STRAFE || !shouldWork()) return@listener
+        listen<MovementEvent.InputUpdate>(Int.MIN_VALUE) {
+            if (mode != Mode.GRIM_STRAFE || !shouldWork()) return@listen
 
             // Delay jumping key state by 1 tick to let the rotation predict jump timing
             it.input.apply {

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.movement
 
 import com.lambda.event.events.RotationEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.rotation.Rotation.Companion.rotationTo
 import com.lambda.module.Module
 import com.lambda.module.modules.combat.KillAura
@@ -49,7 +49,7 @@ object TargetStrafe : Module(
     val isActive get() = isEnabled && KillAura.isEnabled && KillAura.target != null
 
     init {
-        listener<TickEvent.Post> {
+        listen<TickEvent.Post> {
             if (player.horizontalCollision) strafeDirection *= -1
 
             if (KillAura.target == null) {
@@ -58,7 +58,7 @@ object TargetStrafe : Module(
             }
         }
 
-        listener<RotationEvent.StrafeInput> { event ->
+        listen<RotationEvent.StrafeInput> { event ->
             KillAura.target?.let { target ->
                 event.strafeYaw = player.eyePos.rotationTo(target.boundingBox.center).yaw
 

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/TickShift.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/TickShift.kt
@@ -21,7 +21,7 @@ import com.lambda.context.SafeContext
 import com.lambda.event.events.ClientEvent
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.modules.combat.KillAura
 import com.lambda.module.tag.ModuleTag
@@ -64,7 +64,7 @@ object TickShift : Module(
     private var lastBoost = 0L
 
     init {
-        listener<TickEvent.Post> {
+        listen<TickEvent.Post> {
             if (Blink.isEnabled) {
                 this@TickShift.info("TickShift is incompatible with blink")
                 disable()
@@ -83,8 +83,8 @@ object TickShift : Module(
             }
         }
 
-        listener<PacketEvent.Send.Pre> {
-            if (it.packet !is PlayerMoveC2SPacket) return@listener
+        listen<PacketEvent.Send.Pre> {
+            if (it.packet !is PlayerMoveC2SPacket) return@listen
             if (!strict) balance--
         }
 
@@ -101,33 +101,33 @@ object TickShift : Module(
             }
         }
 
-        listener<ClientEvent.Timer> {
+        listen<ClientEvent.Timer> {
             if (!isActive) {
                 poolPackets()
-                return@listener
+                return@listen
             }
 
             it.speed = if (boost) boostAmount else slowdown
         }
 
-        listener<PacketEvent.Send.Pre> { event ->
-            if (!isActive || !grim || event.isCanceled()) return@listener
-            if (event.packet !is CommonPongC2SPacket) return@listener
+        listen<PacketEvent.Send.Pre> { event ->
+            if (!isActive || !grim || event.isCanceled()) return@listen
+            if (event.packet !is CommonPongC2SPacket) return@listen
 
             pingPool.add(event.packet)
             event.cancel()
-            return@listener
+            return@listen
         }
 
-        listener<PacketEvent.Receive.Pre> { event ->
-            if (!isActive || !grim || !shiftVelocity || event.isCanceled()) return@listener
+        listen<PacketEvent.Receive.Pre> { event ->
+            if (!isActive || !grim || !shiftVelocity || event.isCanceled()) return@listen
 
-            if (event.packet !is EntityVelocityUpdateS2CPacket) return@listener
-            if (event.packet.id != player.id) return@listener
+            if (event.packet !is EntityVelocityUpdateS2CPacket) return@listen
+            if (event.packet.id != player.id) return@listen
 
             lastVelocity = event.packet
             event.cancel()
-            return@listener
+            return@listen
         }
 
         onEnable {

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/Timer.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/Timer.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.movement
 
 import com.lambda.event.events.ClientEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 
@@ -30,7 +30,7 @@ object Timer : Module(
     private val timer by setting("Timer", 1.0, 0.0..10.0, 0.01)
 
     init {
-        listener<ClientEvent.Timer> {
+        listen<ClientEvent.Timer> {
             it.speed = timer.coerceAtLeast(0.05)
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/network/PacketDelay.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/network/PacketDelay.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.network
 import com.lambda.context.SafeContext
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.RenderEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.threading.runConcurrent
@@ -51,14 +51,14 @@ object PacketDelay : Module(
     private var inboundLastUpdate = 0L
 
     init {
-        listener<RenderEvent.World> {
-            if (mode != Mode.STATIC) return@listener
+        listen<RenderEvent.World> {
+            if (mode != Mode.STATIC) return@listen
 
             flushPools(System.currentTimeMillis())
         }
 
-        listener<PacketEvent.Send.Pre>(Int.MIN_VALUE) { event ->
-            if (!packetScope.filter(event.packet)) return@listener
+        listen<PacketEvent.Send.Pre>(Int.MIN_VALUE) { event ->
+            if (!packetScope.filter(event.packet)) return@listen
 
             when (mode) {
                 Mode.STATIC -> {
@@ -78,8 +78,8 @@ object PacketDelay : Module(
             }
         }
 
-        listener<PacketEvent.Receive.Pre>(Int.MIN_VALUE) { event ->
-            if (!packetScope.filter(event.packet)) return@listener
+        listen<PacketEvent.Receive.Pre>(Int.MIN_VALUE) { event ->
+            if (!packetScope.filter(event.packet)) return@listen
 
             when (mode) {
                 Mode.STATIC -> {

--- a/common/src/main/kotlin/com/lambda/module/modules/network/PacketLimiter.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/network/PacketLimiter.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.network
 
 import com.lambda.event.events.PacketEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.util.Communication.info
@@ -60,11 +60,11 @@ object PacketLimiter : Module(
             packetQueue = LimitedDecayQueue(limit, interval)
         }
 
-        listener<PacketEvent.Send.Pre>(Int.MAX_VALUE) {
-            if (it.packet::class.simpleName in ignorePackets) return@listener
+        listen<PacketEvent.Send.Pre>(Int.MAX_VALUE) {
+            if (it.packet::class.simpleName in ignorePackets) return@listen
 
 //            this@PacketLimiter.info("Packet sent: ${it.packet::class.simpleName} (${packetQueue.size} / $limit) ${Instant.now()}")
-            if (packetQueue.add(it)) return@listener
+            if (packetQueue.add(it)) return@listen
 
             it.cancel()
             this@PacketLimiter.info("Packet limit reached, dropping packet: ${it.packet::class.simpleName} (${packetQueue.size} / $limit)")

--- a/common/src/main/kotlin/com/lambda/module/modules/network/PacketLogger.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/network/PacketLogger.kt
@@ -21,8 +21,8 @@ import com.lambda.Lambda
 import com.lambda.Lambda.mc
 import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeConcurrentListener
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeListener
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafeConcurrently
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.threading.runIO
@@ -155,45 +155,45 @@ object PacketLogger : Module(
             }
         }
 
-        unsafeListener<TickEvent.Pre> {
-            if (!logTicks) return@unsafeListener
+        listenUnsafe<TickEvent.Pre> {
+            if (!logTicks) return@listenUnsafe
 
             storageFlow.tryEmit("Started tick at ${getTime(entryFormatter)}\n\n")
         }
 
-        unsafeListener<PacketEvent.Receive.Pre> {
+        listenUnsafe<PacketEvent.Receive.Pre> {
             if (logConcurrent
                 || !scope.shouldLog(it.packet)
                 || !networkSide.shouldLog(NetworkSide.SERVER)
-            ) return@unsafeListener
+            ) return@listenUnsafe
 
             it.packet.logReceived()
         }
 
-        unsafeListener<PacketEvent.Send.Pre> {
+        listenUnsafe<PacketEvent.Send.Pre> {
             if (logConcurrent
                 || !scope.shouldLog(it.packet)
                 || !networkSide.shouldLog(NetworkSide.CLIENT)
-            ) return@unsafeListener
+            ) return@listenUnsafe
 
 
             it.packet.logSent()
         }
 
-        unsafeConcurrentListener<PacketEvent.Receive.Pre> {
+        listenUnsafeConcurrently<PacketEvent.Receive.Pre> {
             if (!logConcurrent
                 || !scope.shouldLog(it.packet)
                 || !networkSide.shouldLog(NetworkSide.SERVER)
-            ) return@unsafeConcurrentListener
+            ) return@listenUnsafeConcurrently
 
             it.packet.logReceived()
         }
 
-        unsafeConcurrentListener<PacketEvent.Send.Pre> {
+        listenUnsafeConcurrently<PacketEvent.Send.Pre> {
             if (!logConcurrent
                 || !scope.shouldLog(it.packet)
                 || !networkSide.shouldLog(NetworkSide.CLIENT)
-            ) return@unsafeConcurrentListener
+            ) return@listenUnsafeConcurrently
 
             it.packet.logSent()
         }

--- a/common/src/main/kotlin/com/lambda/module/modules/network/Rubberband.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/network/Rubberband.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.network
 
 import com.lambda.event.events.PacketEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.PlayerPacketManager
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
@@ -45,13 +45,13 @@ object Rubberband : Module(
     private val showRubberbandInfo by setting("Show Rubberband Info", true)
 
     init {
-        listener<PacketEvent.Receive.Pre> { event ->
-            if (!showRubberbandInfo) return@listener
-            if (event.packet !is PlayerPositionLookS2CPacket) return@listener
+        listen<PacketEvent.Receive.Pre> { event ->
+            if (!showRubberbandInfo) return@listen
+            if (event.packet !is PlayerPositionLookS2CPacket) return@listen
 
             if (PlayerPacketManager.configurations.isEmpty()) {
                 this@Rubberband.warn("Position was reverted")
-                return@listener
+                return@listen
             }
 
             val newPos = Vec3d(event.packet.x, event.packet.y, event.packet.z)

--- a/common/src/main/kotlin/com/lambda/module/modules/network/ServerSpoof.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/network/ServerSpoof.kt
@@ -18,7 +18,7 @@
 package com.lambda.module.modules.network
 
 import com.lambda.event.events.PacketEvent
-import com.lambda.event.listener.UnsafeListener.Companion.unsafeListener
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.util.Communication.info
@@ -44,20 +44,20 @@ object ServerSpoof : Module(
     private val cancelResourcePack by setting("Cancel Resource Pack Loading", true)
 
     init {
-        unsafeListener<PacketEvent.Send.Pre> {
+        listenUnsafe<PacketEvent.Send.Pre> {
             val packet = it.packet
-            if (packet !is CustomPayloadC2SPacket) return@unsafeListener
+            if (packet !is CustomPayloadC2SPacket) return@listenUnsafe
             val payload = packet.payload
-            if (payload !is BrandCustomPayload) return@unsafeListener
-            if (!spoofClientBrand || payload.id() != BrandCustomPayload.ID) return@unsafeListener
+            if (payload !is BrandCustomPayload) return@listenUnsafe
+            if (!spoofClientBrand || payload.id() != BrandCustomPayload.ID) return@listenUnsafe
 
             payload.write(PacketByteBuf(Unpooled.buffer()).writeString(spoofName))
         }
 
-        unsafeListener<PacketEvent.Receive.Pre> { event ->
+        listenUnsafe<PacketEvent.Receive.Pre> { event ->
             val packet = event.packet
-            if (!cancelResourcePack) return@unsafeListener
-            if (packet !is ResourcePackSendS2CPacket) return@unsafeListener
+            if (!cancelResourcePack) return@listenUnsafe
+            if (packet !is ResourcePackSendS2CPacket) return@listenUnsafe
 
             event.cancel()
 

--- a/common/src/main/kotlin/com/lambda/module/modules/player/FastBreak.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/player/FastBreak.kt
@@ -19,7 +19,7 @@ package com.lambda.module.modules.player
 
 import com.lambda.context.SafeContext
 import com.lambda.event.events.*
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.DynamicAABB
 import com.lambda.graphics.renderer.esp.builders.buildFilled
 import com.lambda.graphics.renderer.esp.builders.buildOutline
@@ -83,10 +83,10 @@ object FastBreak : Module(
     }
 
     init {
-        listener<PacketEvent.Send.Pre> {
+        listen<PacketEvent.Send.Pre> {
             if (it.packet !is PlayerActionC2SPacket
                 || it.packet.action != Action.STOP_DESTROY_BLOCK
-            ) return@listener
+            ) return@listen
 
             connection.sendPacket(
                 PlayerActionC2SPacket(
@@ -100,24 +100,24 @@ object FastBreak : Module(
             )
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             interaction.blockBreakingCooldown = interaction.blockBreakingCooldown.coerceAtMost(breakDelay)
         }
 
-        listener<PlayerEvent.Breaking.Update> {
+        listen<PlayerEvent.Breaking.Update> {
             it.progress += world.getBlockState(it.pos)
                 .calcBlockBreakingDelta(player, world, it.pos) * (1 - breakThreshold)
         }
 
-        listener<TickEvent.Post> {
-            if (!renderMode.isEnabled()) return@listener
+        listen<TickEvent.Post> {
+            if (!renderMode.isEnabled()) return@listen
 
             val pos = interaction.currentBreakingPos
             boxSet = world.getBlockState(pos).getOutlineShape(world, pos).boundingBoxes.toSet()
         }
 
-        listener<RenderEvent.World> {
-            if (!interaction.isBreakingBlock || !renderMode.isEnabled()) return@listener
+        listen<RenderEvent.World> {
+            if (!interaction.isBreakingBlock || !renderMode.isEnabled()) return@listen
 
             val pos = interaction.currentBreakingPos
             val breakDelta = world.getBlockState(pos).calcBlockBreakingDelta(player, world, pos)

--- a/common/src/main/kotlin/com/lambda/module/modules/player/Freecam.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/player/Freecam.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.player
 import com.lambda.Lambda.mc
 import com.lambda.config.groups.IRotationConfig
 import com.lambda.event.events.*
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.rotation.Rotation
 import com.lambda.interaction.rotation.Rotation.Companion.rotationTo
 import com.lambda.interaction.rotation.RotationContext
@@ -94,15 +94,15 @@ object Freecam : Module(
             mc.options.perspective = lastPerspective
         }
 
-        listener<RotationEvent.Update>(Int.MAX_VALUE) { event ->
-            if (!rotateToTarget) return@listener
-            val target = mc.crosshairTarget?.orNull ?: return@listener
+        listen<RotationEvent.Update>(Int.MAX_VALUE) { event ->
+            if (!rotateToTarget) return@listen
+            val target = mc.crosshairTarget?.orNull ?: return@listen
 
             val rotation = player.eyePos.rotationTo(target.pos)
             event.context = RotationContext(rotation, rotationConfig)
         }
 
-        listener<PlayerEvent.ChangeLookDirection> {
+        listen<PlayerEvent.ChangeLookDirection> {
             rotation = rotation.withDelta(
                 it.deltaYaw * SENSITIVITY_FACTOR,
                 it.deltaPitch * SENSITIVITY_FACTOR
@@ -110,7 +110,7 @@ object Freecam : Module(
             it.cancel()
         }
 
-        listener<MovementEvent.InputUpdate> { event ->
+        listen<MovementEvent.InputUpdate> { event ->
             mc.options.perspective = Perspective.FIRST_PERSON
 
             // Don't block baritone from working
@@ -135,7 +135,7 @@ object Freecam : Module(
             position += velocity
         }
 
-        listener<RenderEvent.UpdateTarget> {
+        listen<RenderEvent.UpdateTarget> {
             it.cancel()
 
             mc.crosshairTarget = rotation
@@ -143,7 +143,7 @@ object Freecam : Module(
                 .orMiss // Can't be null (otherwise mc will spam "Null returned as 'hitResult', this shouldn't happen!")
         }
 
-        listener<ConnectionEvent.Disconnect> {
+        listen<ConnectionEvent.Disconnect> {
             disable()
         }
     }

--- a/common/src/main/kotlin/com/lambda/module/modules/player/InventoryTweaks.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/player/InventoryTweaks.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.player
 import com.lambda.context.SafeContext
 import com.lambda.event.events.PlayerEvent
 import com.lambda.event.events.ScreenHandlerEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
 import com.lambda.task.Task
@@ -50,10 +50,10 @@ object InventoryTweaks : Module(
     private var lastOpenScreen: ScreenHandler? = null
 
     init {
-        listener<PlayerEvent.SlotClick> {
-            if (it.action != SlotActionType.PICKUP || it.button != 1) return@listener
+        listen<PlayerEvent.SlotClick> {
+            if (it.action != SlotActionType.PICKUP || it.button != 1) return@listen
             val stack = it.screenHandler.getSlot(it.slot).stack
-            if (!(instantShulker && stack.item in shulkerBoxes) && !(instantEChest && stack.item == Items.ENDER_CHEST)) return@listener
+            if (!(instantShulker && stack.item in shulkerBoxes) && !(instantEChest && stack.item == Items.ENDER_CHEST)) return@listen
             it.cancel()
             move(it.slot, stack)
 
@@ -67,8 +67,8 @@ object InventoryTweaks : Module(
             }.start(null)
         }
 
-        listener<ScreenHandlerEvent.Close> { event ->
-            if (event.screenHandler != lastOpenScreen) return@listener
+        listen<ScreenHandlerEvent.Close> { event ->
+            if (event.screenHandler != lastOpenScreen) return@listen
             lastOpenScreen = null
             placedPos?.let {
                 lastBreak = breakAndCollectBlock(it).start(null)

--- a/common/src/main/kotlin/com/lambda/module/modules/player/PacketMine.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/player/PacketMine.kt
@@ -20,7 +20,7 @@ package com.lambda.module.modules.player
 import com.lambda.Lambda.mc
 import com.lambda.context.SafeContext
 import com.lambda.event.events.*
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.DynamicAABB
 import com.lambda.graphics.renderer.esp.builders.buildFilled
 import com.lambda.graphics.renderer.esp.builders.buildOutline
@@ -273,11 +273,11 @@ object PacketMine : Module(
     private var doubleBreakReturnSlot = 0
 
     init {
-        listener<PlayerEvent.Breaking.Update> {
+        listen<PlayerEvent.Breaking.Update> {
             swingingNextAttack = false
         }
 
-        listener<PlayerEvent.Attack.Block> {
+        listen<PlayerEvent.Attack.Block> {
             it.cancel()
             if (swingOnManual) swingMainHand()
 
@@ -294,10 +294,10 @@ object PacketMine : Module(
                     } else {
                         blockQueue.add(it.pos)
                     }
-                    return@listener
+                    return@listen
                 }
 
-                if (blockQueue.contains(it.pos)) return@listener
+                if (blockQueue.contains(it.pos)) return@listen
             }
 
             currentMiningBlock.forEach { ctx ->
@@ -306,9 +306,9 @@ object PacketMine : Module(
 
                     val primary = breakType.isPrimary()
 
-                    if (!primary || (breakState == BreakState.ReBreaking && !reBreak.isStandard())) return@listener
+                    if (!primary || (breakState == BreakState.ReBreaking && !reBreak.isStandard())) return@listen
 
-                    if (miningProgress < breakThreshold) return@listener
+                    if (miningProgress < breakThreshold) return@listen
 
                     runBetweenHandlers(ProgressStage.EndPre, ProgressStage.EndPost, pos, { lastValidBestTool }) {
                         packetStopBreak(pos)
@@ -316,7 +316,7 @@ object PacketMine : Module(
                         onBlockBreak()
                     }
 
-                    return@listener
+                    return@listen
                 }
             }
 
@@ -332,17 +332,17 @@ object PacketMine : Module(
             startBreaking(it.pos)
         }
 
-        listener<PlayerEvent.SwingHand> {
-            if (!cancelNextSwing) return@listener
+        listen<PlayerEvent.SwingHand> {
+            if (!cancelNextSwing) return@listen
 
             cancelNextSwing = false
             it.cancel()
         }
 
-        listener<TickEvent.Pre>(1) {
+        listen<TickEvent.Pre>(1) {
             updateCounters()
 
-            if (shouldWaitForQueuePause()) return@listener
+            if (shouldWaitForQueuePause()) return@listen
 
             currentMiningBlock.forEach { ctx ->
                 ctx?.apply {
@@ -508,13 +508,13 @@ object PacketMine : Module(
             }
         }
 
-        listener<TickEvent.Post> {
+        listen<TickEvent.Post> {
             if (doubleBreakSwapped && doubleBreakSwappedCounter >= 1) {
                 returnToOriginalDoubleBreakSlot()
             }
         }
 
-        listener<WorldEvent.BlockUpdate> {
+        listen<WorldEvent.BlockUpdate> {
             currentMiningBlock.forEach { ctx ->
                 ctx?.apply {
                     if (it.pos != pos || !isStateBroken(pos.blockState(world), it.state)) return@forEach
@@ -532,8 +532,8 @@ object PacketMine : Module(
             }
         }
 
-        listener<RotationEvent.Update> {
-            if (!rotate.isEnabled()) return@listener
+        listen<RotationEvent.Update> {
+            if (!rotate.isEnabled()) return@listen
 
             rotationPosition?.let { pos ->
                 lastNonEmptyState?.let { state ->
@@ -549,7 +549,7 @@ object PacketMine : Module(
                 expectedRotation = null
             }
 
-            if (!rotated || !waitingToReleaseRotation) return@listener
+            if (!rotated || !waitingToReleaseRotation) return@listen
 
             releaseRotateDelayCounter--
 
@@ -560,14 +560,14 @@ object PacketMine : Module(
             }
         }
 
-        listener<RotationEvent.Post> {
-            if (!rotate.isEnabled()) return@listener
+        listen<RotationEvent.Post> {
+            if (!rotate.isEnabled()) return@listen
 
             expectedRotation?.let { expectedRot ->
                 rotationPosition?.let { pos ->
                     if (it.context != expectedRot) {
                         pausedForRotation = true
-                        return@listener
+                        return@listen
                     }
 
                     val boxList = lastNonEmptyState?.getOutlineShape(world, pos)?.boundingBoxes?.map { it.offset(pos) }
@@ -584,7 +584,7 @@ object PacketMine : Module(
                         pausedForRotation = true
                     }
 
-                    return@listener
+                    return@listen
                 }
             }
 
@@ -592,7 +592,7 @@ object PacketMine : Module(
             pausedForRotation = false
         }
 
-        listener<RenderEvent.World> {
+        listen<RenderEvent.World> {
             renderer.clear()
 
             currentMiningBlock.forEach { ctx ->

--- a/common/src/main/kotlin/com/lambda/module/modules/player/Replay.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/player/Replay.kt
@@ -26,7 +26,7 @@ import com.lambda.event.EventFlow.lambdaScope
 import com.lambda.event.events.KeyboardEvent
 import com.lambda.event.events.MovementEvent
 import com.lambda.event.events.RotationEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.rotation.Rotation
 import com.lambda.interaction.rotation.RotationContext
 import com.lambda.interaction.rotation.RotationMode
@@ -111,8 +111,8 @@ object Replay : Module(
         .create()
 
     init {
-        listener<KeyboardEvent.Press> {
-            if (mc.currentScreen != null && !mc.options.commandKey.isPressed) return@listener
+        listen<KeyboardEvent.Press> {
+            if (mc.currentScreen != null && !mc.options.commandKey.isPressed) return@listen
 
             when (it.translated) {
                 record -> handleRecord()
@@ -123,7 +123,7 @@ object Replay : Module(
             }
         }
 
-        listener<MovementEvent.InputUpdate> { event ->
+        listen<MovementEvent.InputUpdate> { event ->
             when (state) {
                 State.RECORDING -> {
                     buffer?.let {
@@ -147,7 +147,7 @@ object Replay : Module(
                             if (cancelOnDeviation && diff > deviationThreshold) {
                                 state = State.INACTIVE
                                 this@Replay.logError("Replay cancelled due to exceeding deviation threshold.")
-                                return@listener
+                                return@listen
                             }
                         }
                     }
@@ -157,7 +157,7 @@ object Replay : Module(
             }
         }
 
-        listener<RotationEvent.Update> { event ->
+        listen<RotationEvent.Update> { event ->
             when (state) {
                 State.RECORDING -> {
                     buffer?.rotation?.add(player.rotation)
@@ -173,7 +173,7 @@ object Replay : Module(
             }
         }
 
-        listener<MovementEvent.Sprint> { event ->
+        listen<MovementEvent.Sprint> { event ->
             when (state) {
                 State.RECORDING -> {
                     buffer?.sprint?.add(player.isSprinting)
@@ -190,7 +190,7 @@ object Replay : Module(
             }
         }
 
-        listener<MovementEvent.Player.Post> {
+        listen<MovementEvent.Player.Post> {
             when (state) {
                 State.RECORDING -> {
                     buffer?.let {
@@ -218,7 +218,7 @@ object Replay : Module(
 
                 State.PLAYING -> {
                     buffer?.let {
-                        if (it.size != 0) return@listener
+                        if (it.size != 0) return@listen
 
                         if (playMode == PlayMode.LOOP && (repeats < loops || loops < 0)) {
                             if (repeats >= 0) repeats++
@@ -241,7 +241,7 @@ object Replay : Module(
                                     color(GuiSettings.primaryColor) { literal(playback?.duration.toString()) }
                                     literal(".")
                                 })
-                                return@listener
+                                return@listen
                             }
 
                             state = State.RECORDING

--- a/common/src/main/kotlin/com/lambda/module/modules/player/Scaffold.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/player/Scaffold.kt
@@ -21,7 +21,7 @@ import com.lambda.config.groups.InteractionSettings
 import com.lambda.config.groups.RotationSettings
 import com.lambda.context.SafeContext
 import com.lambda.event.events.*
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.renderer.esp.DirectionMask
 import com.lambda.graphics.renderer.esp.DirectionMask.buildSideMesh
 import com.lambda.graphics.renderer.esp.builders.build
@@ -129,11 +129,11 @@ object Scaffold : Module(
             }
         )
 
-        listener<MovementEvent.Sneak> {
+        listen<MovementEvent.Sneak> {
             if (sneakTicks > 0) it.sneak = true
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             placeInfo?.let { info ->
                 tickPlacement(info)
             }
@@ -141,7 +141,7 @@ object Scaffold : Module(
             updateSneaking()
         }
 
-        listener<RenderEvent.StaticESP> { event ->
+        listen<RenderEvent.StaticESP> { event ->
             buildRenderer(event)
         }
 

--- a/common/src/main/kotlin/com/lambda/module/modules/render/Particles.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/render/Particles.kt
@@ -23,7 +23,7 @@ import com.lambda.event.events.PlayerEvent
 import com.lambda.event.events.MovementEvent
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.graphics.buffer.VertexPipeline
 import com.lambda.graphics.buffer.vertex.attributes.VertexAttrib
 import com.lambda.graphics.buffer.vertex.attributes.VertexMode
@@ -83,12 +83,12 @@ object Particles : Module(
     private val shader = Shader("renderer/particle", "renderer/particle")
 
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             if (environment) spawnForEnvironment()
             particles.removeIf(Particle::update)
         }
 
-        listener<RenderEvent.World> {
+        listen<RenderEvent.World> {
             // Todo: interpolated tickbased upload?
             particles.forEach(Particle::build)
 
@@ -102,12 +102,12 @@ object Particles : Module(
             }
         }
 
-        listener<PlayerEvent.Attack.Entity> { event ->
+        listen<PlayerEvent.Attack.Entity> { event ->
             spawnForEntity(event.entity)
         }
 
-        listener<MovementEvent.Player.Post> {
-            if (!onMove || player.moveDelta < 0.05) return@listener
+        listen<MovementEvent.Player.Post> {
+            if (!onMove || player.moveDelta < 0.05) return@listen
             spawnForEntity(player)
         }
     }

--- a/common/src/main/kotlin/com/lambda/task/Task.kt
+++ b/common/src/main/kotlin/com/lambda/task/Task.kt
@@ -23,7 +23,7 @@ import com.lambda.event.Event
 import com.lambda.event.EventFlow
 import com.lambda.event.Subscriber
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.module.modules.client.TaskFlow
 import com.lambda.threading.runConcurrent
 import com.lambda.threading.runGameScheduled
@@ -116,7 +116,7 @@ abstract class Task<Result> : Nameable {
     }
 
     init {
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             parent?.let {
                 it.age++
             }
@@ -460,7 +460,7 @@ abstract class Task<Result> : Nameable {
     inline fun <reified T : Event> withListener(
         crossinline action: SafeContext.(Task<Result>) -> Unit
     ): Task<Result> {
-        listener<T> {
+        listen<T> {
             action(this@Task)
         }
         return this

--- a/common/src/main/kotlin/com/lambda/task/tasks/BreakBlock.kt
+++ b/common/src/main/kotlin/com/lambda/task/tasks/BreakBlock.kt
@@ -24,7 +24,7 @@ import com.lambda.context.SafeContext
 import com.lambda.event.events.RotationEvent
 import com.lambda.event.events.TickEvent
 import com.lambda.event.events.WorldEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.construction.context.BreakContext
 import com.lambda.interaction.visibilty.VisibilityChecker.lookAtBlock
 import com.lambda.module.modules.client.TaskFlow
@@ -77,24 +77,24 @@ class BreakBlock @Ta5kBuilder constructor(
     }
 
     init {
-        listener<RotationEvent.Update> { event ->
-            if (state != State.BREAKING) return@listener
-            if (!rotate || ctx.instantBreak) return@listener
+        listen<RotationEvent.Update> { event ->
+            if (state != State.BREAKING) return@listen
+            if (!rotate || ctx.instantBreak) return@listen
             event.context = lookAtBlock(blockPos, rotation, interact, sides)
         }
 
-        listener<RotationEvent.Post> {
-            if (state != State.BREAKING) return@listener
-            if (!rotate || ctx.instantBreak) return@listener
+        listen<RotationEvent.Post> {
+            if (state != State.BREAKING) return@listen
+            if (!rotate || ctx.instantBreak) return@listen
 
             isValid = it.context.isValid
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             drop?.let { itemDrop ->
                 if (!world.entities.contains(itemDrop)) {
                     success(itemDrop)
-                    return@listener
+                    return@listen
                 }
 
                 if (player.hotbarAndStorage.none { it.isEmpty }) {
@@ -120,7 +120,7 @@ class BreakBlock @Ta5kBuilder constructor(
             }
         }
 
-        listener<WorldEvent.EntityUpdate> {
+        listen<WorldEvent.EntityUpdate> {
             if (collectDrop
                 && it.entity is ItemEntity
                 && it.entity.pos.isInRange(blockPos.toCenterPos(), 0.5)

--- a/common/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
+++ b/common/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
@@ -21,7 +21,7 @@ import com.lambda.Lambda.LOG
 import com.lambda.context.SafeContext
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.construction.Blueprint
 import com.lambda.interaction.construction.Blueprint.Companion.toStructure
 import com.lambda.interaction.construction.DynamicBlueprint
@@ -54,13 +54,13 @@ class BuildTask @Ta5kBuilder constructor(
     }
 
     init {
-        listener<RenderEvent.StaticESP> {
+        listen<RenderEvent.StaticESP> {
             previousResults.filterIsInstance<Drawable>().forEach { res ->
                 with(res) { buildRenderer() }
             }
         }
 
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             pending.removeIf {
                 if (it.age > placeTimeout) {
                     it.cancel()
@@ -74,7 +74,7 @@ class BuildTask @Ta5kBuilder constructor(
 
             if (finishOnDone && blueprint.structure.isEmpty()) {
                 failure("Structure is empty")
-                return@listener
+                return@listen
             }
 
             val results = blueprint.simulate(player.getCameraPosVec(mc.tickDelta))
@@ -90,18 +90,18 @@ class BuildTask @Ta5kBuilder constructor(
                     pending.add(it)
                     it.start(this@BuildTask, pauseParent = false)
                 }
-                return@listener
+                return@listen
             }
 
             if (pending.isNotEmpty()) {
-                return@listener
+                return@listen
             }
 
-            val result = results.minOrNull() ?: return@listener
+            val result = results.minOrNull() ?: return@listen
             when {
                 !result.rank.solvable -> {
 //                    info("Unsolvable: $result")
-                    if (!blueprint.isDone(this)) return@listener
+                    if (!blueprint.isDone(this)) return@listen
                     success(Unit)
                 }
 

--- a/common/src/main/kotlin/com/lambda/task/tasks/InventoryTask.kt
+++ b/common/src/main/kotlin/com/lambda/task/tasks/InventoryTask.kt
@@ -19,7 +19,7 @@ package com.lambda.task.tasks
 
 import com.lambda.context.SafeContext
 import com.lambda.event.events.TickEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.material.StackSelection
 import com.lambda.module.modules.client.TaskFlow
 import com.lambda.task.Task
@@ -54,7 +54,7 @@ class InventoryTask(
     init {
         // ToDo: Needs smart code to move as efficient as possible.
         //  Also should handle overflow etc. Should be more generic
-        listener<TickEvent.Pre> {
+        listen<TickEvent.Pre> {
             val moved = selector.filterSlots(to)
                 .filter { it.hasStack() }
                 .sumOf { it.stack.count } >= selector.count

--- a/common/src/main/kotlin/com/lambda/task/tasks/OpenContainer.kt
+++ b/common/src/main/kotlin/com/lambda/task/tasks/OpenContainer.kt
@@ -21,7 +21,7 @@ import com.lambda.config.groups.IRotationConfig
 import com.lambda.config.groups.InteractionConfig
 import com.lambda.event.events.RotationEvent
 import com.lambda.event.events.ScreenHandlerEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.visibilty.VisibilityChecker.lookAtBlock
 import com.lambda.module.modules.client.TaskFlow
 import com.lambda.task.Task
@@ -50,8 +50,8 @@ class OpenContainer(
     }
 
     init {
-        listener<ScreenHandlerEvent.Open> {
-            if (state != State.OPENING) return@listener
+        listen<ScreenHandlerEvent.Open> {
+            if (state != State.OPENING) return@listen
 
             screenHandler = it.screenHandler
             state = State.SLOT_LOADING
@@ -59,33 +59,33 @@ class OpenContainer(
             if (!waitForSlotLoad) success(it.screenHandler)
         }
 
-        listener<ScreenHandlerEvent.Close> {
-            if (screenHandler != it.screenHandler) return@listener
+        listen<ScreenHandlerEvent.Close> {
+            if (screenHandler != it.screenHandler) return@listen
 
             state = State.SCOPING
             screenHandler = null
         }
 
-        listener<ScreenHandlerEvent.Update> {
-            if (state != State.SLOT_LOADING) return@listener
+        listen<ScreenHandlerEvent.Update> {
+            if (state != State.SLOT_LOADING) return@listen
 
             screenHandler?.let {
                 success(it)
             }
         }
 
-        listener<RotationEvent.Update> { event ->
-            if (!rotate) return@listener
+        listen<RotationEvent.Update> { event ->
+            if (!rotate) return@listen
             event.context = lookAtBlock(blockPos, rotation, interact, sides)
         }
 
-        listener<RotationEvent.Post> {
-            if (!rotate) return@listener
-            if (state != State.SCOPING) return@listener
-            if (!it.context.isValid) return@listener
+        listen<RotationEvent.Post> {
+            if (!rotate) return@listen
+            if (state != State.SCOPING) return@listen
+            if (!it.context.isValid) return@listen
 
             if (inScope++ >= interact.scopeThreshold) {
-                val hitResult = it.context.hitResult?.blockResult ?: return@listener
+                val hitResult = it.context.hitResult?.blockResult ?: return@listen
                 interaction.interactBlock(player, Hand.MAIN_HAND, hitResult)
 
                 state = State.OPENING

--- a/common/src/main/kotlin/com/lambda/task/tasks/PlaceBlock.kt
+++ b/common/src/main/kotlin/com/lambda/task/tasks/PlaceBlock.kt
@@ -23,7 +23,7 @@ import com.lambda.context.SafeContext
 import com.lambda.event.events.RotationEvent
 import com.lambda.event.events.TickEvent
 import com.lambda.event.events.WorldEvent
-import com.lambda.event.listener.SafeListener.Companion.listener
+import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.interaction.construction.context.PlaceContext
 import com.lambda.module.modules.client.TaskFlow
 import com.lambda.task.Task
@@ -64,30 +64,30 @@ class PlaceBlock @Ta5kBuilder constructor(
     }
 
     init {
-        listener<RotationEvent.Update> { event ->
-            if (state != State.ROTATING) return@listener
-            if (!rotate) return@listener
+        listen<RotationEvent.Update> { event ->
+            if (state != State.ROTATING) return@listen
+            if (!rotate) return@listen
             event.context = ctx.rotation
         }
 
-        listener<RotationEvent.Post> { event ->
-            if (state != State.ROTATING) return@listener
-            if (!rotate) return@listener
-            if (event.context != ctx.rotation) return@listener
-            if (!event.context.isValid) return@listener
+        listen<RotationEvent.Post> { event ->
+            if (state != State.ROTATING) return@listen
+            if (!rotate) return@listen
+            if (event.context != ctx.rotation) return@listen
+            if (!event.context.isValid) return@listen
 
             state = State.PLACING
         }
 
-        listener<TickEvent.Pre> {
-            if (state != State.PLACING) return@listener
+        listen<TickEvent.Pre> {
+            if (state != State.PLACING) return@listen
 
             if (findOutIfNeeded) placeBlock()
             findOutIfNeeded = true
         }
 
-        listener<WorldEvent.BlockUpdate> {
-            if (it.pos != ctx.resultingPos) return@listener
+        listen<WorldEvent.BlockUpdate> {
+            if (it.pos != ctx.resultingPos) return@listen
 
             if (ctx.targetState.matches(it.state, it.pos, world)) {
                 finish()

--- a/common/src/main/kotlin/com/lambda/threading/Threading.kt
+++ b/common/src/main/kotlin/com/lambda/threading/Threading.kt
@@ -23,6 +23,7 @@ import com.lambda.context.SafeContext
 import com.lambda.event.EventFlow
 import com.mojang.blaze3d.systems.RenderSystem.isOnRenderThread
 import com.mojang.blaze3d.systems.RenderSystem.recordRenderCall
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
@@ -52,13 +53,13 @@ inline fun <T> runSafe(block: SafeContext.() -> T) =
  *
  * @param block The block of code to be executed concurrently.
  */
-inline fun runConcurrent(crossinline block: suspend () -> Unit) =
-    EventFlow.lambdaScope.launch {
+inline fun runConcurrent(scheduler: CoroutineDispatcher = Dispatchers.Default, crossinline block: suspend () -> Unit) =
+    EventFlow.lambdaScope.launch(scheduler) {
         block()
     }
 
 inline fun runIO(crossinline block: suspend () -> Unit) =
-    EventFlow.lambdaScope.launch(Dispatchers.IO) {
+    runConcurrent(Dispatchers.IO) {
         block()
     }
 


### PR DESCRIPTION
### Semmantics
Changed
```kotlin
listener<TickEvent.Pre> { }
listenOnce<TickEvent.Pre> {}
concurrentListener<TickEvent.Pre> { }
unsafeListener<TickEvent.Pre> {}
```
to
```kotlin
listen<TickEvent.Pre> { }
listenOnce<TickEvent.Pre> {}
listenConcurrently<TickEvent.Pre> { }
listenUnsafe<TickEvent.Pre> {}
```
as its more naturally readable.

### Scheduling
Now you can pass the scheduling dispatcher to the concurrent listener:
```kotlin
listenConcurrently<Data.Safe>(Dispatchers.IO) { }
```