### PR TITLE
[1.20.4] [All] Bug: Logo not found even if it was found

### DIFF
--- a/common/src/main/java/com/lambda/mixin/render/SplashOverlayMixin.java
+++ b/common/src/main/java/com/lambda/mixin/render/SplashOverlayMixin.java
@@ -17,7 +17,12 @@
 
 package com.lambda.mixin.render;
 
+import com.lambda.util.LambdaResource;
 import net.minecraft.client.gui.screen.SplashOverlay;
+import net.minecraft.client.texture.ResourceTexture;
+import net.minecraft.resource.DefaultResourcePack;
+import net.minecraft.resource.InputSupplier;
+import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ColorHelper;
 import org.spongepowered.asm.mixin.Final;
@@ -29,6 +34,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.io.InputStream;
 import java.util.function.IntSupplier;
 
 @Mixin(SplashOverlay.class)
@@ -46,5 +52,17 @@ public class SplashOverlayMixin {
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onInit(CallbackInfo ci) {
         LOGO = Identifier.of("lambda", "textures/lambda_banner.png");
+    }
+
+    @Mixin(SplashOverlay.LogoTexture.class)
+    static class LogoTextureMixin extends ResourceTexture {
+        @Redirect(method = "loadTextureData", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/DefaultResourcePack;open(Lnet/minecraft/resource/ResourceType;Lnet/minecraft/util/Identifier;)Lnet/minecraft/resource/InputSupplier;"))
+        InputSupplier<InputStream> loadTextureData(DefaultResourcePack instance, ResourceType type, Identifier id) {
+            return () -> new LambdaResource("textures/lambda_banner.png").getStream();
+        }
+
+        public LogoTextureMixin(Identifier location) {
+            super(location);
+        }
     }
 }

--- a/common/src/main/resources/lambda.accesswidener
+++ b/common/src/main/resources/lambda.accesswidener
@@ -35,6 +35,7 @@ accessible method net/minecraft/client/render/Camera setRotation (FF)V
 accessible field com/mojang/blaze3d/systems/RenderSystem$ShapeIndexBuffer id I
 accessible field net/minecraft/client/render/BufferRenderer currentVertexBuffer Lnet/minecraft/client/gl/VertexBuffer;
 accessible field net/minecraft/client/texture/NativeImage pointer J
+accessible class net/minecraft/client/gui/screen/SplashOverlay$LogoTexture
 
 # Text
 accessible field net/minecraft/text/Style color Lnet/minecraft/text/TextColor;

--- a/common/src/main/resources/lambda.mixins.common.json
+++ b/common/src/main/resources/lambda.mixins.common.json
@@ -41,6 +41,7 @@
     "render.RenderTickCounterMixin",
     "render.ScreenHandlerMixin",
     "render.SplashOverlayMixin",
+    "render.SplashOverlayMixin$LogoTextureMixin",
     "render.VertexBufferMixin",
     "render.WorldRendererMixin",
     "world.BlockCollisionSpliteratorMixin",


### PR DESCRIPTION
Closes #91 

This pull request fixes the lambda banner mixin by redirecting the splash overlay `LogoTexture` class' `loadTextureData` which uses internal path segments to resolve resources
![image](https://github.com/user-attachments/assets/a8ce5c98-6f5c-4e90-b4b8-93c0c30d238e)
