### PR TITLE
[1.20.4] Feat: Buffered flow timer

### DIFF
--- a/common/src/main/kotlin/com/lambda/event/EventFlow.kt
+++ b/common/src/main/kotlin/com/lambda/event/EventFlow.kt
@@ -95,6 +95,32 @@ object EventFlow {
     }
 
     /**
+     * Registers a timer that invokes the specified block at regular intervals
+     *
+     * This function runs a timer that emits a signal at the specified interval, and invokes the
+     * provided block each time the signal is emitted. The interval is specified in milliseconds,
+     * and the block is a suspend function that is called each time the timer triggers
+     *
+     * **Note**: This function uses a flow to emit signals at the specified interval, and uses `conflate()`
+     * to prevent overloading the block execution in case the block takes longer than the interval
+     *
+     * @param interval The time interval (in milliseconds) between each invocation of the block
+     * @param block The suspend function that will be called each time the timer triggers
+     *
+     * @return A [Job] representing the running timer. The timer can be canceled by invoking `cancel()` on the returned job
+     */
+    inline fun timer(interval: Long, crossinline block: suspend () -> Unit) =
+        runConcurrent {
+            // This allows for 18,446,744,073,709,551,615 events
+            // Don't worry, a 10 ms timer will end after 5.849 billion years
+            (Long.MAX_VALUE downTo Long.MIN_VALUE)
+                .asFlow()
+                .onEach { delay(interval) }
+                .conflate()
+                .collect { block() }
+        }
+
+    /**
      * Suspends until an event of type [E] is received that satisfies the given [predicate].
      *
      * @param E The type of the event to wait for. This should be a subclass of [Event].
@@ -123,7 +149,7 @@ object EventFlow {
         noinline predicate: (E) -> Boolean = { true },
     ) = runBlocking {
         withTimeout(timeout) {
-            concurrentFlow.filterIsInstance<E>().first(predicate)
+            this@EventFlow.concurrentFlow.filterIsInstance<E>().first(predicate)
         }
     }
 
@@ -150,7 +176,7 @@ object EventFlow {
     suspend inline fun <reified E : Event> collectEvents(
         crossinline predicate: (E) -> Boolean = { true },
     ): Flow<E> = flow {
-        concurrentFlow
+        this@EventFlow.concurrentFlow
             .filterIsInstance<E>()
             .filter { predicate(it) }
             .collect {
@@ -175,7 +201,7 @@ object EventFlow {
      */
     @JvmStatic
     fun <E : Event> E.post(): E {
-        concurrentFlow.tryEmit(this)
+        this@EventFlow.concurrentFlow.tryEmit(this)
         executeListenerSynchronous()
         return this@post
     }


### PR DESCRIPTION
This pull request implements a simple yet efficient timer using kotlin's flow
This is the code used for testing:
```kt
var time: Long
var time2: Long

timer(1000L) {
    time = System.currentTimeMillis()
    delay(1000L)
    info("Time1: ${System.currentTimeMillis() - time} milliseconds")
}

timer(1000L) {
    time2 = System.currentTimeMillis()
    delay(2000L)
    info("Timer2: ${System.currentTimeMillis() - time2} milliseconds")
}
```

There was an ever so slightly sleep deviation between 1 to 4 milliseconds, this was most likely caused by the `System.currentTimeMillis()`, [shown as here](https://programming.vip/docs/performance-problems-and-solutions-of-system.currenttimemillis.html)