### PR TITLE
[1.20.4] Ref: Inline setting event functions

### DIFF
--- a/common/src/main/kotlin/com/lambda/config/AbstractSetting.kt
+++ b/common/src/main/kotlin/com/lambda/config/AbstractSetting.kt
@@ -39,6 +39,7 @@ import net.minecraft.command.CommandRegistryAccess
 import java.lang.reflect.Type
 import kotlin.properties.Delegates
 import kotlin.reflect.KProperty
+import kotlin.to
 
 /**
  * Represents a setting with a [defaultValue], [visibility] condition, and [description].
@@ -125,7 +126,7 @@ abstract class AbstractSetting<T : Any>(
      * Will only register changes of the variable, not the content of the variable!
      * E.g., if the variable is a list, it will only register if the list reference changes, not if the content of the list changes.
      */
-    fun onValueChange(block: SafeContext.(from: T, to: T) -> Unit) {
+    fun onValueChange(block: SafeContext.(from: T, to: T) -> Unit) = apply {
         listeners.add(ValueListener(true) { from, to ->
             runSafe {
                 block(from, to)
@@ -133,11 +134,11 @@ abstract class AbstractSetting<T : Any>(
         })
     }
 
-    fun onValueChangeUnsafe(block: (from: T, to: T) -> Unit) {
+    fun onValueChangeUnsafe(block: (from: T, to: T) -> Unit) = apply {
         listeners.add(ValueListener(true, block))
     }
 
-    fun onValueSet(block: (from: T, to: T) -> Unit) {
+    fun onValueSet(block: (from: T, to: T) -> Unit) = apply {
         listeners.add(ValueListener(false, block))
     }
 

--- a/common/src/main/kotlin/com/lambda/module/HudModule.kt
+++ b/common/src/main/kotlin/com/lambda/module/HudModule.kt
@@ -52,25 +52,19 @@ abstract class HudModule(
         override val width get() = this@HudModule.width
         override val height get() = this@HudModule.height
 
-        override val autoDocking by setting("Auto Docking", true).apply {
-            onValueChange { _, _ ->
-                autoDocking()
-            }
-        }
+        override val autoDocking by setting("Auto Docking", true).onValueChange { _, _ -> autoDocking() }
 
-        override var dockingH by setting("Docking H", HAlign.LEFT) { !autoDocking }.apply {
-            onValueChange { from, to ->
+        override var dockingH by setting("Docking H", HAlign.LEFT) { !autoDocking }
+            .onValueChange { from, to ->
                 val delta = to.multiplier - from.multiplier
                 relativePosX += delta * (size.x - screenSize.x)
             }
-        }
 
-        override var dockingV by setting("Docking V", VAlign.TOP) { !autoDocking }.apply {
-            onValueChange { from, to ->
+        override var dockingV by setting("Docking V", VAlign.TOP) { !autoDocking }
+            .onValueChange { from, to ->
                 val delta = to.multiplier - from.multiplier
                 relativePosY += delta * (size.y - screenSize.y)
             }
-        }
     }
 
     var position by rectHandler::position

--- a/common/src/main/kotlin/com/lambda/module/modules/client/DiscordRPC.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/client/DiscordRPC.kt
@@ -70,8 +70,7 @@ object DiscordRPC : Module(
 
     /* Party settings */
     private val enableParty by setting("Enable Party", true, description = "Allows you to create parties.") { page == Page.Party }
-    private val maxPlayers by setting("Max Players", 10, 2..20) { page == Page.Party }
-        .apply { onValueChange { _, _ -> if (player.isPartyOwner) edit() } }
+    private val maxPlayers by setting("Max Players", 10, 2..20) { page == Page.Party }.onValueChange { _, _ -> if (player.isPartyOwner) edit() }
 
     private val rpc = KDiscordIPC(Lambda.APP_ID, scope = EventFlow.lambdaScope)
     private var startup = System.currentTimeMillis()

--- a/common/src/main/kotlin/com/lambda/module/modules/client/GuiSettings.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/client/GuiSettings.kt
@@ -35,11 +35,8 @@ object GuiSettings : Module(
     private val page by setting("Page", Page.General)
 
     // General
-    private val scaleSetting by setting("Scale", 100, 50..300, 1, unit = "%", visibility = { page == Page.General }).apply {
-        onValueSet { _, _ ->
-            lastChange = System.currentTimeMillis()
-        }
-    }
+    private val scaleSetting by setting("Scale", 100, 50..300, 1, unit = "%", visibility = { page == Page.General })
+		.onValueSet { _, _ -> lastChange = System.currentTimeMillis() }
 
     // Colors
     val primaryColor by setting("Primary Color", Color(130, 200, 255), visibility = { page == Page.Colors })

--- a/common/src/main/kotlin/com/lambda/module/modules/movement/Speed.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/movement/Speed.kt
@@ -49,11 +49,7 @@ object Speed : Module(
     defaultTags = setOf(ModuleTag.MOVEMENT)
 ) {
     @JvmStatic
-    val mode by setting("Mode", Mode.GRIM_STRAFE).apply {
-        onValueChange { _, _ ->
-            Speed.reset()
-        }
-    }
+    val mode by setting("Mode", Mode.GRIM_STRAFE).onValueChange { _, _ -> reset() }
 
     // Grim
     private val diagonal by setting("Diagonal", true) { mode == Mode.GRIM_STRAFE }

--- a/common/src/main/kotlin/com/lambda/module/modules/network/PacketLimiter.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/network/PacketLimiter.kt
@@ -34,16 +34,11 @@ object PacketLimiter : Module(
     defaultTags = setOf(ModuleTag.NETWORK)
 ) {
     private var packetQueue = LimitedDecayQueue<PacketEvent.Send.Pre>(99, 1000)
-    private val limit by setting("Limit", 99, 1..100, 1, "The maximum amount of packets to send per given time interval", unit = " packets").apply {
-        onValueChange { _, to ->
-            packetQueue.setMaxSize(to)
-        }
-    }
-    private val interval by setting("Duration", 1000L, 1L..1000L, 50L, "The interval / duration in milliseconds to limit packets for", unit = " ms").apply {
-        onValueChange { _, to ->
-            packetQueue.setDecayTime(to)
-        }
-    }
+    private val limit by setting("Limit", 99, 1..100, 1, "The maximum amount of packets to send per given time interval", unit = " packets")
+        .onValueChange { _, to -> packetQueue.setMaxSize(to) }
+    
+    private val interval by setting("Duration", 1000L, 1L..1000L, 50L, "The interval / duration in milliseconds to limit packets for", unit = " ms")
+        .onValueChange { _, to -> packetQueue.setDecayTime(to) }
 
     private val defaultIgnorePackets = setOf(
         CommonPongC2SPacket::class,

--- a/common/src/main/kotlin/com/lambda/module/modules/player/PacketMine.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/player/PacketMine.kt
@@ -89,7 +89,9 @@ object PacketMine : Module(
     private val emptyReBreakDelay by setting("Empty Re-Break Delay", 0, 0..10, 1, "The delay between attempting to re-break the block if the block is currently empty", " ticks", visibility = { page == Page.ReBreak && reBreak.isFastAutomatic()})
     private val renderIfEmpty by setting("Render If Empty", false, "Draws the renders even if the re-break position is empty in the world", visibility = { page == Page.ReBreak && reBreak.isEnabled() })
 
-    private val queueBlocks by setting("Queue Blocks", false, "Queues any blocks you click for breaking", visibility = { page == Page.Queue }).apply { this.onValueSet { _, to -> if (!to) blockQueue.clear() } }
+    private val queueBlocks by setting("Queue Blocks", false, "Queues any blocks you click for breaking", visibility = { page == Page.Queue })
+        .onValueSet { _, to -> if (!to) blockQueue.clear() }
+
     private val reverseQueueOrder by setting("Reverse Queue Order", false, "Breaks the latest addition to the queue first", visibility = { page == Page.Queue && queueBlocks})
     private val queueBreakDelay by setting("Break Delay", 0, 0..5, 1, "The delay after breaking a block to break the next queue block", " ticks", visibility = { page == Page.Queue && queueBlocks })
 

--- a/common/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
@@ -43,17 +43,17 @@ object BlockESP : Module(
     description = "Render block ESP",
     defaultTags = setOf(ModuleTag.RENDER)
 ) {
-    private var drawFaces: Boolean by setting("Draw Faces", true, "Draw faces of blocks").apply { onValueSet(::rebuildMesh); onValueSet { _, to -> if (!to) drawOutlines = true } }
-    private var drawOutlines: Boolean by setting("Draw Outlines", true, "Draw outlines of blocks").apply { onValueSet(::rebuildMesh); onValueSet { _, to -> if (!to) drawFaces = true } }
-    private val mesh by setting("Mesh", true, "Connect similar adjacent blocks").apply { onValueSet(::rebuildMesh) }
+    private var drawFaces: Boolean by setting("Draw Faces", true, "Draw faces of blocks").onValueSet(::rebuildMesh).onValueSet { _, to -> if (!to) drawOutlines = true }
+    private var drawOutlines: Boolean by setting("Draw Outlines", true, "Draw outlines of blocks").onValueSet(::rebuildMesh).onValueSet { _, to -> if (!to) drawFaces = true }
+    private val mesh by setting("Mesh", true, "Connect similar adjacent blocks").onValueSet(::rebuildMesh)
 
-    private val useBlockColor by setting("Use Block Color", false, "Use the color of the block instead").apply { onValueSet(::rebuildMesh) }
-    private val faceColor by setting("Face Color", Color(100, 150, 255, 51), "Color of the surfaces") { drawFaces && !useBlockColor }.apply { onValueSet(::rebuildMesh) }
-    private val outlineColor by setting("Outline Color", Color(100, 150, 255, 128), "Color of the outlines") { drawOutlines && !useBlockColor }.apply { onValueSet(::rebuildMesh) }
+    private val useBlockColor by setting("Use Block Color", false, "Use the color of the block instead").onValueSet(::rebuildMesh)
+    private val faceColor by setting("Face Color", Color(100, 150, 255, 51), "Color of the surfaces") { drawFaces && !useBlockColor }.onValueSet(::rebuildMesh)
+    private val outlineColor by setting("Outline Color", Color(100, 150, 255, 128), "Color of the outlines") { drawOutlines && !useBlockColor }.onValueSet(::rebuildMesh)
 
-    private val outlineMode by setting("Outline Mode", DirectionMask.OutlineMode.AND, "Outline mode").apply { onValueSet(::rebuildMesh) }
+    private val outlineMode by setting("Outline Mode", DirectionMask.OutlineMode.AND, "Outline mode").onValueSet(::rebuildMesh)
 
-    private val blocks by setting("Blocks", setOf(Blocks.BEDROCK), "Render blocks").apply { onValueSet(::rebuildMesh) }
+    private val blocks by setting("Blocks", setOf(Blocks.BEDROCK), "Render blocks").onValueSet(::rebuildMesh)
 
     @JvmStatic
     val barrier by setting("Solid Barrier Block", true, "Render barrier blocks")

--- a/common/src/main/kotlin/com/lambda/module/modules/render/StorageESP.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/render/StorageESP.kt
@@ -64,8 +64,8 @@ object StorageESP : Module(
     private val distance by setting("Distance", 64.0, 10.0..256.0, 1.0, "Maximum distance for rendering") { page == Page.General }
 
     /* Render settings */
-    private var drawFaces: Boolean by setting("Draw Faces", true, "Draw faces of blocks") { page == Page.Render }.apply { onValueSet { _, to -> if (!to) drawOutlines = true } }
-    private var drawOutlines: Boolean by setting("Draw Outlines", true, "Draw outlines of blocks") { page == Page.Render }.apply { onValueSet { _, to -> if (!to) drawFaces = true } }
+    private var drawFaces: Boolean by setting("Draw Faces", true, "Draw faces of blocks") { page == Page.Render }.onValueSet { _, to -> if (!to) drawOutlines = true }
+    private var drawOutlines: Boolean by setting("Draw Outlines", true, "Draw outlines of blocks") { page == Page.Render }.onValueSet { _, to -> if (!to) drawFaces = true }
     private val outlineMode by setting("Outline Mode", DirectionMask.OutlineMode.AND, "Outline mode") { page == Page.Render }
     private val mesh by setting("Mesh", true, "Connect similar adjacent blocks") { page == Page.Render }
 


### PR DESCRIPTION
This pull request changes the `AbstractSetting` event subscribers such as `onValueChanged`, `onValueSet` and others to facilitate subscription without having to wrap it in an `apply block`

Before:
```kt
private val mesh by setting("Mesh", true, "Connect similar adjacent blocks").apply { onValueSet(::rebuildMesh) }
```

After
```kt
private val mesh by setting("Mesh", true, "Connect similar adjacent blocks").onValueSet(::rebuildMesh)
```

Instead, we call `apply` in the event subscription event
```kt
fun onValueSet(block: (from: T, to: T) -> Unit) = apply {
    listeners.add(ValueListener(false, block))
}
```