### PR TITLE
Bring back default keybind for ClickGUI

### DIFF
--- a/common/src/main/kotlin/com/lambda/module/modules/client/ClickGui.kt
+++ b/common/src/main/kotlin/com/lambda/module/modules/client/ClickGui.kt
@@ -42,7 +42,8 @@ import kotlin.math.hypot
 object ClickGui : Module(
     name = "ClickGui",
     description = "sexy again",
-    defaultTags = setOf(ModuleTag.CLIENT)
+    defaultTags = setOf(ModuleTag.CLIENT),
+    defaultKeybind = KeyCode.Y
 ) {
     val titleBarHeight by setting("Title Bar Height", 18.0, 10.0..25.0, 0.1)
     val moduleHeight by setting("Module Height", 16.0, 10.0..25.0, 0.1)


### PR DESCRIPTION
### Description
Brings back the default keybind for ClickGUI, which for some reason got removed in 6c90f18c85a77190108a9806fc386f6910462586

