### PR TITLE
Change default font size to 18 pixels

### DIFF
--- a/src/main/kotlin/com/lambda/gui/DearImGui.kt
+++ b/src/main/kotlin/com/lambda/gui/DearImGui.kt
@@ -73,7 +73,7 @@ object DearImGui : Loadable {
                 ImGuiConfigFlags.DockingEnable
 
         io.iniFilename = "lambda.ini"
-        io.fonts.addFontFromFileTTF("fonts/FiraSans-Regular.ttf".path, 13f)
+        io.fonts.addFontFromFileTTF("fonts/FiraSans-Regular.ttf".path, 18f)
         io.fonts.build()
 
         implGlfw.init(mc.window.handle, true)


### PR DESCRIPTION
This allows the user to scale down the size if wanted, rather than scaling up and losing quality