### PR TITLE
Sort Modules in lambda click ui by name

### DIFF
--- a/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
+++ b/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
@@ -202,6 +202,7 @@ object ClickGuiLayout : Loadable, Configurable(GuiConfig) {
                     window(tag.name, flags = AlwaysAutoResize) {
                         ModuleRegistry.modules
                             .filter { it.tag == tag }
+                            .sortedBy { it.name }
                             .forEach { with(ModuleEntry(it)) { buildLayout() } }
                     }
                 }

--- a/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
+++ b/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
@@ -202,7 +202,6 @@ object ClickGuiLayout : Loadable, Configurable(GuiConfig) {
                     window(tag.name, flags = AlwaysAutoResize) {
                         ModuleRegistry.modules
                             .filter { it.tag == tag }
-                            .sortedBy { it.name }
                             .forEach { with(ModuleEntry(it)) { buildLayout() } }
                     }
                 }

--- a/src/main/kotlin/com/lambda/module/ModuleRegistry.kt
+++ b/src/main/kotlin/com/lambda/module/ModuleRegistry.kt
@@ -25,7 +25,7 @@ import com.lambda.util.reflections.getInstances
  */
 object ModuleRegistry : Loadable {
     override val priority = 1
-    val modules = getInstances<Module>().toMutableList()
+    val modules = getInstances<Module>().toMutableList().sortedBy { it.name }
 
     val moduleNames: Set<String>
         get() = modules.map { it.name }.toSet()


### PR DESCRIPTION
# Description
This change sorts click UI elements in the lambda click UI by name from top to bottom. This should make it easier to find modules by name.

