### PR TITLE
Fix: CollectionSettings mapping stringified values instead of converting the collection to a tree

### DIFF
--- a/src/main/kotlin/com/lambda/config/Configurable.kt
+++ b/src/main/kotlin/com/lambda/config/Configurable.kt
@@ -151,32 +151,21 @@ abstract class Configurable(
     ) = Setting(name, description, ItemCollectionSetting(immutableCollection, defaultValue.toMutableList()), this, visibility).register()
 
 	@JvmName("collectionSetting3")
-    inline fun <reified T : Comparable<T>> setting(
+    inline fun <reified T : Any> setting(
         name: String,
         defaultValue: Collection<T>,
         immutableList: Collection<T> = defaultValue,
         description: String = "",
+        displayClassName: Boolean = false,
         noinline visibility: () -> Boolean = { true },
     ) = Setting(
 	    name,
 	    description,
-	    CollectionSetting(
-		    defaultValue.toMutableList(),
-		    immutableList,
-		    TypeToken.getParameterized(Collection::class.java, T::class.java).type
-		),
+        if (displayClassName) ClassCollectionSetting(immutableList, defaultValue.toMutableList())
+                else CollectionSetting(defaultValue.toMutableList(), immutableList, TypeToken.getParameterized(Collection::class.java, T::class.java).type),
 		this,
 	    visibility
 	).register()
-
-	@JvmName("collectionSetting4")
-    inline fun <reified T : Any> setting(
-	    name: String,
-	    defaultValue: Collection<T>,
-	    immutableList: Collection<T> = defaultValue,
-	    description: String = "",
-	    noinline visibility: () -> Boolean = { true },
-    ) = Setting(name, description, ClassCollectionSetting(immutableList, defaultValue.toMutableList()), this, visibility).register()
 
     // ToDo: Actually implement maps
     inline fun <reified K : Any, reified V : Any> setting(

--- a/src/main/kotlin/com/lambda/config/groups/BreakSettings.kt
+++ b/src/main/kotlin/com/lambda/config/groups/BreakSettings.kt
@@ -57,7 +57,7 @@ open class BreakSettings(
     override val breakDelay by c.setting("Break Delay", 0, 0..5, 1, "The delay between breaking blocks", " tick(s)").group(baseGroup, Group.General).index()
 
     // Timing
-    override val tickStageMask by c.setting("Break Stage Mask", setOf(TickEvent.Input.Post), ALL_STAGES.toSet(), description = "The sub-tick timing at which break actions can be performed").group(baseGroup, Group.General).index()
+    override val tickStageMask by c.setting("Break Stage Mask", setOf(TickEvent.Input.Post), ALL_STAGES.toSet(), "The sub-tick timing at which break actions can be performed", displayClassName = true).group(baseGroup, Group.General).index()
 
     // Swap
     override val swapMode by c.setting("Break Swap Mode", BreakConfig.SwapMode.End, "Decides when to swap to the best suited tool when breaking a block").group(baseGroup, Group.General).index()

--- a/src/main/kotlin/com/lambda/config/groups/HotbarSettings.kt
+++ b/src/main/kotlin/com/lambda/config/groups/HotbarSettings.kt
@@ -33,5 +33,5 @@ class HotbarSettings(
     override val swapDelay by c.setting("Swap Delay", 0, 0..3, 1, "The number of ticks delay before allowing another hotbar selection swap", " ticks").group(baseGroup).index()
     override val swapsPerTick by c.setting("Swaps Per Tick", 3, 1..10, 1, "The number of hotbar selection swaps that can take place each tick") { swapDelay <= 0 }.group(baseGroup).index()
     override val swapPause by c.setting("Swap Pause", 0, 0..20, 1, "The delay in ticks to pause actions after switching to the slot", " ticks").group(baseGroup).index()
-    override val tickStageMask by c.setting("Hotbar Stage Mask", setOf(TickEvent.Input.Post), ALL_STAGES.toSet(), description = "The sub-tick timing at which hotbar actions are performed").group(baseGroup).index()
+    override val tickStageMask by c.setting("Hotbar Stage Mask", setOf(TickEvent.Input.Post), ALL_STAGES.toSet(), "The sub-tick timing at which hotbar actions are performed", displayClassName = true).group(baseGroup).index()
 }

--- a/src/main/kotlin/com/lambda/config/groups/InteractSettings.kt
+++ b/src/main/kotlin/com/lambda/config/groups/InteractSettings.kt
@@ -34,7 +34,7 @@ class InteractSettings(
     override val airPlace by c.setting("Air Place", AirPlaceMode.None, "Allows for placing blocks without adjacent faces").group(baseGroup).index()
     override val axisRotateSetting by c.setting("Axis Rotate", true, "Overrides the Rotate For Place setting and rotates the player on each axis to air place rotational blocks") { airPlace.isEnabled }.group(baseGroup).index()
     override val sorter by c.setting("Interaction Sorter", ActionConfig.SortMode.Tool, "The order in which placements are performed").group(baseGroup).index()
-    override val tickStageMask by c.setting("Interaction Stage Mask", setOf(TickEvent.Input.Post), ALL_STAGES.toSet(), description = "The sub-tick timing at which place actions are performed").group(baseGroup).index()
+    override val tickStageMask by c.setting("Interaction Stage Mask", setOf(TickEvent.Input.Post), ALL_STAGES.toSet(), "The sub-tick timing at which place actions are performed", displayClassName = true).group(baseGroup).index()
     override val interactConfirmationMode by c.setting("Interact Confirmation", InteractConfirmationMode.PlaceThenAwait, "Wait for block placement confirmation").group(baseGroup).index()
     override val interactDelay by c.setting("Interact Delay", 0, 0..3, 1, "Tick delay between interacting with another block").group(baseGroup).index()
     override val interactionsPerTick by c.setting("Interactions Per Tick", 1, 1..30, 1, "Maximum instant block places per tick").group(baseGroup).index()

--- a/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
@@ -17,6 +17,7 @@
 
 package com.lambda.config.settings.collections
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.reflect.TypeToken
 import com.lambda.Lambda.gson
@@ -106,7 +107,7 @@ open class CollectionSetting<R : Any>(
 
 	context(setting: Setting<*, MutableCollection<R>>)
     override fun toJson(): JsonElement =
-        gson.toJsonTree(value.map { it.toString() })
+		gson.toJsonTree(value)
 
 	context(setting: Setting<*, MutableCollection<R>>)
     override fun loadFromJson(serialized: JsonElement) {


### PR DESCRIPTION
This pull request modifies slightly comparable collection settings by converting the entire tree directly instead of mapping the collection values to their stringified representations. Collection setting of comparable types was removed and a new flag was introduce to chose the setting core before creating the setting. This pull request also fixes the friend list being serialized using the class collection setting core.