### PR TITLE
Fix: Transparency for block colors in blockesp

### DIFF
--- a/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
+++ b/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
@@ -29,7 +29,6 @@ import com.lambda.module.tag.ModuleTag
 import com.lambda.threading.runSafe
 import com.lambda.util.extension.blockColor
 import com.lambda.util.extension.getBlockState
-import com.lambda.util.math.setAlpha
 import com.lambda.util.world.toBlockPos
 import net.minecraft.block.Blocks
 import net.minecraft.client.render.model.BlockStateModel
@@ -51,6 +50,8 @@ object BlockESP : Module(
     private val mesh by setting("Mesh", true, "Connect similar adjacent blocks") { searchBlocks }.onValueChange(::rebuildMesh)
 
     private val useBlockColor by setting("Use Block Color", false, "Use the color of the block instead") { searchBlocks }.onValueChange(::rebuildMesh)
+    private val blockColorAlpha by setting("Block Color Alpha", 0.3, 0.1..1.0, 0.05) { searchBlocks && useBlockColor }.onValueChange { _, _ -> ::rebuildMesh }
+
     private val faceColor by setting("Face Color", Color(100, 150, 255, 51), "Color of the surfaces") { searchBlocks && drawFaces && !useBlockColor }.onValueChange(::rebuildMesh)
     private val outlineColor by setting("Outline Color", Color(100, 150, 255, 128), "Color of the outlines") { searchBlocks && drawOutlines && !useBlockColor }.onValueChange(::rebuildMesh)
 
@@ -78,7 +79,7 @@ object BlockESP : Module(
 
         runSafe {
             val extractedColor = blockColor(state, position.toBlockPos())
-            val finalColor = Color(extractedColor.red, extractedColor.green, extractedColor.blue, faceColor.alpha)
+            val finalColor = Color(extractedColor.red, extractedColor.green, extractedColor.blue, (blockColorAlpha * 255).toInt())
             val pos = position.toBlockPos()
             val shape = state.getOutlineShape(world, pos)
             val worldBox = if (shape.isEmpty) Box(pos) else shape.boundingBox.offset(pos)

--- a/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
+++ b/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
@@ -78,6 +78,7 @@ object BlockESP : Module(
         } else DirectionMask.ALL
 
         runSafe {
+            // TODO: Add custom color option when map options are implemented
             val extractedColor = blockColor(state, position.toBlockPos())
             val finalColor = Color(extractedColor.red, extractedColor.green, extractedColor.blue, (blockColorAlpha * 255).toInt())
             val pos = position.toBlockPos()

--- a/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
+++ b/src/main/kotlin/com/lambda/module/modules/render/BlockESP.kt
@@ -29,6 +29,7 @@ import com.lambda.module.tag.ModuleTag
 import com.lambda.threading.runSafe
 import com.lambda.util.extension.blockColor
 import com.lambda.util.extension.getBlockState
+import com.lambda.util.math.setAlpha
 import com.lambda.util.world.toBlockPos
 import net.minecraft.block.Blocks
 import net.minecraft.client.render.model.BlockStateModel
@@ -77,12 +78,13 @@ object BlockESP : Module(
 
         runSafe {
             val extractedColor = blockColor(state, position.toBlockPos())
+            val finalColor = Color(extractedColor.red, extractedColor.green, extractedColor.blue, faceColor.alpha)
             val pos = position.toBlockPos()
             val shape = state.getOutlineShape(world, pos)
             val worldBox = if (shape.isEmpty) Box(pos) else shape.boundingBox.offset(pos)
             box(worldBox) {
                 if (drawFaces)
-                    filled(if (useBlockColor) extractedColor else faceColor, sides)
+                    filled(if (useBlockColor) finalColor else faceColor, sides)
                 if (drawOutlines)
                     outline(if (useBlockColor) extractedColor else BlockESP.outlineColor, sides, BlockESP.outlineMode)
             }

--- a/src/main/kotlin/com/lambda/util/extension/World.kt
+++ b/src/main/kotlin/com/lambda/util/extension/World.kt
@@ -53,8 +53,15 @@ fun SafeContext.collisionShape(state: BlockState, pos: BlockPos): VoxelShape =
 fun SafeContext.outlineShape(state: BlockState, pos: BlockPos) =
     state.getOutlineShape(world, pos).offset(pos)
 
-fun SafeContext.blockColor(state: BlockState, pos: BlockPos) =
-    Color(state.getMapColor(world, pos).color)
+fun SafeContext.blockColor(state: BlockState, pos: BlockPos): Color {
+    return when (state.block) {
+        Blocks.ENDER_CHEST -> Color(0xFF00FF)
+        Blocks.NETHER_PORTAL -> Color(0xaa00aa)
+        Blocks.END_PORTAL -> Color(0xFF00FF)
+        else ->
+        Color(state.getMapColor(world, pos).color, false)
+    }
+}
 
 fun World.getBlockState(x: Int, y: Int, z: Int): BlockState {
     if (isOutOfHeightLimit(y)) return Blocks.VOID_AIR.defaultState


### PR DESCRIPTION
Now it has transparency when using the block color mode. And custom colors for portals and Ender Chests cuz they don't have good colors from the map color map.