### PR TITLE
Feat: Client module toggles for loading screen and UI sounds

### DIFF
--- a/src/main/java/com/lambda/mixin/render/SplashOverlayMixin.java
+++ b/src/main/java/com/lambda/mixin/render/SplashOverlayMixin.java
@@ -17,6 +17,7 @@
 
 package com.lambda.mixin.render;
 
+import com.lambda.module.modules.client.Client;
 import com.lambda.util.LambdaResourceKt;
 import net.minecraft.client.gui.screen.SplashOverlay;
 import net.minecraft.client.texture.ReloadableTexture;
@@ -25,10 +26,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ColorHelper;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -43,13 +41,21 @@ public class SplashOverlayMixin {
     @Final
     public static Identifier LOGO;
 
+    @Unique
+    private static Identifier VANILLA_LOGO;
+
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onInit(CallbackInfo ci) {
-        LOGO = Identifier.of("lambda", "textures/lambda_banner.png");
+        if (VANILLA_LOGO == null) VANILLA_LOGO = LOGO;
+
+        LOGO = (Client.INSTANCE.getLoadScreen())
+                ? Identifier.of("lambda", "textures/lambda_banner.png")
+                : VANILLA_LOGO;
     }
 
     @WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Ljava/util/function/IntSupplier;getAsInt()I"))
     private int wrapBrandArgb(IntSupplier originalSupplier, Operation<Integer> original) {
+        if (!Client.INSTANCE.getLoadScreen()) return original.call(originalSupplier);
         return ColorHelper.getArgb(255, 35, 35, 35);
     }
 
@@ -61,7 +67,12 @@ public class SplashOverlayMixin {
 
         @WrapOperation(method = "loadContents", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ResourceFactory;open(Lnet/minecraft/util/Identifier;)Ljava/io/InputStream;"))
         InputStream wrapLoadTextureData(ResourceFactory instance, Identifier id, Operation<InputStream> original) {
-            return LambdaResourceKt.getStream("textures/lambda_banner.png");
+            if ("lambda".equals(id.getNamespace())
+                    && "textures/lambda_banner.png".equals(id.getPath())) {
+                return LambdaResourceKt.getStream("textures/lambda_banner.png");
+            }
+
+            return original.call(instance, id);
         }
     }
 }

--- a/src/main/kotlin/com/lambda/module/Module.kt
+++ b/src/main/kotlin/com/lambda/module/Module.kt
@@ -36,6 +36,7 @@ import com.lambda.event.listener.Listener
 import com.lambda.event.listener.SafeListener
 import com.lambda.event.listener.SafeListener.Companion.listen
 import com.lambda.event.listener.UnsafeListener
+import com.lambda.module.modules.client.Client
 import com.lambda.module.tag.ModuleTag
 import com.lambda.sound.LambdaSound
 import com.lambda.sound.SoundManager.play
@@ -155,11 +156,12 @@ abstract class Module(
             else if (event.isReleased && disableOnRelease) disable()
         }
 
-        onEnable { LambdaSound.ModuleOn.play() }
-        onDisable { LambdaSound.ModuleOff.play() }
+        onEnable { if (Client.toggleSounds) LambdaSound.ModuleOn.play() }
+        onDisable { if (Client.toggleSounds) LambdaSound.ModuleOff.play() }
 
-        onEnableUnsafe { LambdaSound.ModuleOn.play() }
-        onDisableUnsafe { LambdaSound.ModuleOff.play() }
+        //not sure if these should also be effected, remove if not.
+        onEnableUnsafe { if (Client.toggleSounds) LambdaSound.ModuleOn.play() }
+        onDisableUnsafe { if (Client.toggleSounds) LambdaSound.ModuleOff.play() }
 
         listen<ClientEvent.Shutdown> { if (autoDisable) disable() }
         listen<ClientEvent.Startup> { if (autoDisable) disable() }

--- a/src/main/kotlin/com/lambda/module/modules/client/Client.kt
+++ b/src/main/kotlin/com/lambda/module/modules/client/Client.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Lambda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.lambda.module.modules.client
+
+import com.lambda.module.Module
+import com.lambda.module.tag.ModuleTag
+
+object Client : Module(
+	name = "Client",
+	description = "Customize various client features.",
+	tag = ModuleTag.CLIENT,
+) {
+	val loadScreen by setting("Custom Loading Screen", true)
+	val toggleSounds by setting("Toggle Sounds", true)
+}

--- a/src/main/kotlin/com/lambda/sound/SoundManager.kt
+++ b/src/main/kotlin/com/lambda/sound/SoundManager.kt
@@ -19,6 +19,7 @@ package com.lambda.sound
 
 import com.lambda.Lambda.mc
 import com.lambda.core.Loadable
+import com.lambda.module.modules.client.Client
 import com.lambda.util.math.random
 import net.minecraft.client.sound.PositionedSoundInstance
 import net.minecraft.registry.Registries
@@ -34,6 +35,7 @@ object SoundManager : Loadable {
     }
 
     fun playSoundRandomly(event: SoundEvent, pitch: Double = 1.0, pitchRange: Double = 0.05) {
+        if (!Client.toggleSounds) return
         val actualPitch = (pitch - pitchRange..pitch + pitchRange).random()
 
         mc.soundManager.play(

--- a/src/main/kotlin/com/lambda/sound/SoundManager.kt
+++ b/src/main/kotlin/com/lambda/sound/SoundManager.kt
@@ -35,7 +35,6 @@ object SoundManager : Loadable {
     }
 
     fun playSoundRandomly(event: SoundEvent, pitch: Double = 1.0, pitchRange: Double = 0.05) {
-        if (!Client.toggleSounds) return
         val actualPitch = (pitch - pitchRange..pitch + pitchRange).random()
 
         mc.soundManager.play(


### PR DESCRIPTION
I have introduced a new Client module (in the Client category) that acts as a home for toggles. The module itself has no standalone functionality; it exists solely to expose settings that gate existing client behavior. Currently, it includes a toggle to enable/disable Lambda's custom splash screen, as well as a toggle to enable/disable Lambda's UI sounds.

Due to how the splash overlay and resource reload lifecycle work, the vanilla splash screen may only be fully visible on the subsequent reload after disabling the Lambda splash screen (e.g. a second F3+T). Enabling the Lambda splash screen applies immediately.