### PR TITLE
Fix: Prevent event dispatches from being rescheduled

### DIFF
--- a/src/main/kotlin/com/lambda/event/listener/SafeListener.kt
+++ b/src/main/kotlin/com/lambda/event/listener/SafeListener.kt
@@ -122,9 +122,7 @@ class SafeListener<T : Event>(
             alwaysListen: Boolean = false,
             noinline function: SafeContext.(T) -> Unit = {}
         ): SafeListener<T> {
-            val listener = SafeListener<T>(priority, this, alwaysListen) { event ->
-                runGameScheduled { function(event) }
-            }
+            val listener = SafeListener<T>(priority, this, alwaysListen) { function(it) }
 
             EventFlow.syncListeners.subscribe(listener)
 
@@ -167,9 +165,7 @@ class SafeListener<T : Event>(
             alwaysListen: Boolean = false,
             function: SafeContext.(T) -> Unit = {},
         ): SafeListener<T> {
-            val listener = SafeListener<T>(priority, this, alwaysListen) { event ->
-                runGameScheduled { function(event) }
-            }
+            val listener = SafeListener<T>(priority, this, alwaysListen) { function(it) }
 
             EventFlow.syncListeners.subscribe(kClass, listener)
 

--- a/src/main/kotlin/com/lambda/event/listener/UnsafeListener.kt
+++ b/src/main/kotlin/com/lambda/event/listener/UnsafeListener.kt
@@ -111,9 +111,7 @@ class UnsafeListener<T : Event>(
             alwaysListen: Boolean = false,
             noinline function: (T) -> Unit = {},
         ): UnsafeListener<T> {
-            val listener = UnsafeListener<T>(priority, this, alwaysListen) { event ->
-                function(event)
-            }
+            val listener = UnsafeListener<T>(priority, this, alwaysListen) { function(it) }
 
             EventFlow.syncListeners.subscribe(listener)
 


### PR DESCRIPTION
Closes #182 

This pull request removes the safe listener events from being rescheduled if they are not on the main thread. This change was made in order to remove branching in the logic. The api should not manage at which stage events are dispatched and let the developer manage it themselves. This is potentially a breaking change as the complex inventory system may depend on this bug for its features.