### PR TITLE
Half slabs don't exist in Minecraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Find our backup matrix space at [\#lambda-client:matrix.org](https://app.element
 
 ### Automation Engine
 * **Build Engine:** Full integration with **Litematica** and schematic files for seamless automated building.
-* **Block State Handling:** The build engine natively supports special block states including rotations, attachments (doors, signs, bells), half-slabs, stairs, repeater delay, and even edge cases like flower pots with plants.
+* **Block State Handling:** The build engine natively supports special block states including rotations, attachments (doors, signs, bells), slabs, stairs, repeater delay, and even edge cases like flower pots with plants.
 * **Conflict-Free Orchestration:** A centralized manager system handles all core interactions (placing, breaking, rotating, inventory) to ensure zero conflicts between concurrently running modules.
 
 ### Unmatched Performance


### PR DESCRIPTION
- Fix: Half-slabs don't exist on Minecraft.

### Issue Link

### Description
Self descriptive.

### Checklist Before Submitting
1. Code adheres to the project's style guide and conventions. 👌
2. All tests pass, including newly added tests. 👌
3. Documentation has been updated to reflect any new features or changes. 👌
4. Your PR is limited to a single purpose, avoiding unrelated changes. 👌
