### PR TITLE
List selection popup Model

### DIFF
--- a/src/main/kotlin/com/lambda/config/Configurable.kt
+++ b/src/main/kotlin/com/lambda/config/Configurable.kt
@@ -159,12 +159,16 @@ abstract class Configurable(
         description: String = "",
         displayClassName: Boolean = false,
         serialize: Boolean = false,
+        selectionModel: Boolean = false,
         noinline visibility: () -> Boolean = { true },
     ) = Setting(
 	    name,
 	    description,
-        if (displayClassName) ClassCollectionSetting(immutableList, defaultValue.toMutableList())
-                else CollectionSetting(defaultValue.toMutableList(), immutableList, TypeToken.getParameterized(Collection::class.java, T::class.java).type, serialize),
+        if (displayClassName) {
+            ClassCollectionSetting(immutableList, defaultValue.toMutableList())
+        } else {
+            CollectionSetting(defaultValue.toMutableList(), immutableList, TypeToken.getParameterized(Collection::class.java, T::class.java).type, serialize, selectionModel = selectionModel)
+        },
 		this,
 	    visibility
 	).register()

--- a/src/main/kotlin/com/lambda/config/Setting.kt
+++ b/src/main/kotlin/com/lambda/config/Setting.kt
@@ -176,7 +176,28 @@ class Setting<T : SettingCore<R>, R>(
 			return
 		}
 		if (!silent) ConfigCommand.info(resetMessage(value, core.defaultValue))
-		value = core.defaultValue
+		when (value) {
+			is List<*> -> {
+				@Suppress("UNCHECKED_CAST")
+				(core.value as MutableList<Any>).clear()
+				@Suppress("UNCHECKED_CAST")
+				(core.value as MutableList<Any>).addAll(core.defaultValue as List<Any>)
+			}
+			is Set<*> -> {
+				@Suppress("UNCHECKED_CAST")
+				(core.value as MutableSet<Any>).clear()
+				@Suppress("UNCHECKED_CAST")
+				(core.value as MutableSet<Any>).addAll(core.defaultValue as Set<Any>)
+			}
+			is Map<*, *> -> {
+				@Suppress("UNCHECKED_CAST")
+				(core.value as MutableMap<Any, Any>).clear()
+				@Suppress("UNCHECKED_CAST")
+				(core.value as MutableMap<Any, Any>).putAll(core.defaultValue as Map<Any, Any>)
+			}
+			else
+				-> value = core.defaultValue
+		}
 	}
 
 	fun restoreOriginalCore() {

--- a/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
@@ -68,9 +68,17 @@ open class CollectionSetting<R : Any>(
 
 	context(setting: Setting<*, MutableCollection<R>>)
 	override fun ImGuiBuilder.buildLayout() {
+		val showReset = setting.isModified
+		val resetButtonText = "R"
+
 		buildPopupButtonAndModel("${setting.name}##${setting.name}-CollectionSettingPopup")
 
-		//		buildComboBox("item") { it.toString() }
+		if (showReset) {
+			sameLine()
+			button(resetButtonText) {
+				setting.reset()
+			}
+		}
 	}
 
 	/**

--- a/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
@@ -66,7 +66,7 @@ open class CollectionSetting<R : Any>(
 
 	context(setting: Setting<*, MutableCollection<R>>)
 	override fun ImGuiBuilder.buildLayout() {
-		val popupName = "##${setting.name}-CollectionSettingPopup"
+		val popupName = "${setting.name}##${setting.name}-CollectionSettingPopup"
 
 		val childWidth = 350f
 		val childHeight = 500f

--- a/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
@@ -27,10 +27,13 @@ import com.lambda.config.SettingGroupEditor
 import com.lambda.context.SafeContext
 import com.lambda.gui.dsl.ImGuiBuilder
 import com.lambda.threading.runSafe
+import imgui.ImGui
 import imgui.ImGuiListClipper
 import imgui.callback.ImListClipperCallback
 import imgui.flag.ImGuiChildFlags
 import imgui.flag.ImGuiSelectableFlags.DontClosePopups
+import imgui.flag.ImGuiWindowFlags
+import imgui.type.ImBoolean
 import java.lang.reflect.Type
 
 /**
@@ -52,15 +55,143 @@ open class CollectionSetting<R : Any>(
 	defaultValue,
 	type
 ) {
-    private var searchFilter = ""
-    private val strListType =
-        TypeToken.getParameterized(Collection::class.java, String::class.java).type
+	private var searchFilter = ""
+	private val strListType =
+		TypeToken.getParameterized(Collection::class.java, String::class.java).type
 
-    val selectListeners = mutableListOf<SafeContext.(R) -> Unit>()
-    val deselectListeners = mutableListOf<SafeContext.(R) -> Unit>()
+	val selectListeners = mutableListOf<SafeContext.(R) -> Unit>()
+	val deselectListeners = mutableListOf<SafeContext.(R) -> Unit>()
+
+	val modelSelected = mutableSetOf<R>()
 
 	context(setting: Setting<*, MutableCollection<R>>)
-    override fun ImGuiBuilder.buildLayout() = buildComboBox("item") { it.toString() }
+	override fun ImGuiBuilder.buildLayout() {
+		val popupName = "##${setting.name}-CollectionSettingPopup"
+
+		val childWidth = 350f
+		val childHeight = 500f
+		val buttonColumnWidth = 60f
+		val totalWidth = (childWidth + 10f) * 2 + buttonColumnWidth + 20f
+		val totalHeight = childHeight + 190f
+
+		if (ImGui.button("Edit List##${setting.name}-Edit")) {
+			ImGui.openPopup(popupName)
+		}
+
+		ImGui.setNextWindowSize(totalWidth, totalHeight)
+		val pOpen = ImBoolean(true)
+		if (ImGui.beginPopupModal(popupName, pOpen, ImGuiWindowFlags.NoResize)) {
+			val availableItems = immutableCollection.filter { it !in value }
+			val selectedItems = value.toList()
+
+			inputText("##${setting.name}-SearchBox", ::searchFilter)
+			sameLine()
+			button("X##${setting.name}-ClearSearch") {
+				searchFilter = ""
+			}
+			sameLine()
+			button("Select All##${setting.name}-SelectAll") {
+				immutableCollection.filter { item ->
+					val q = searchFilter.trim()
+					if (q.isEmpty()) true
+					else item.toString().contains(q, ignoreCase = true)
+				}.forEach { item ->
+					modelSelected.add(item)
+				}
+			}
+
+			ImGui.columns(3, "##${setting.name}-Columns", false)
+			ImGui.setColumnWidth(0, childWidth + 10f)
+			ImGui.setColumnWidth(1, buttonColumnWidth)
+
+			// Linke Seite: Verfügbare Elemente
+			ImGui.text("Values")
+			child("##${setting.name}-AvailableChild", childWidth, childHeight, ImGuiChildFlags.Border) {
+				availableItems.filter { item ->
+					val q = searchFilter.trim()
+					if (q.isEmpty()) true
+					else item.toString().contains(q, ignoreCase = true)
+				}.forEach { item ->
+					val selected = item in modelSelected
+					selectable("$item##available", selected) {
+						modelSelected.add(item)
+					}
+				}
+			}
+
+			ImGui.nextColumn()
+
+			// Mittlere Spalte: Buttons
+			ImGui.dummy(0f, 300f)
+			val columnWidth = ImGui.getColumnWidth()
+			val buttonWidth = 40f
+			ImGui.setCursorPosX(ImGui.getCursorPosX() + (columnWidth - buttonWidth) / 2f)
+			if (ImGui.button(">>", buttonWidth, 0f)) {
+				modelSelected
+					.filter { item ->
+						val q = searchFilter.trim()
+						if (q.isEmpty()) true
+						else item.toString().contains(q, ignoreCase = true)
+					}
+					.forEach { item ->
+					if (item in value) return@forEach
+					value.add(item)
+					runSafe { selectListeners.forEach { listener -> listener(item) } }
+				}
+				modelSelected.clear()
+			}
+			ImGui.setCursorPosX(ImGui.getCursorPosX() + (columnWidth - buttonWidth) / 2f)
+			if (ImGui.button("<<", buttonWidth, 0f)) {
+				modelSelected
+					.filter { item ->
+						val q = searchFilter.trim()
+						if (q.isEmpty()) true
+						else item.toString().contains(q, ignoreCase = true)
+					}
+					.forEach { item ->
+					if (item !in value) return@forEach
+					value.remove(item)
+					runSafe { deselectListeners.forEach { listener -> listener(item) } }
+				}
+				modelSelected.clear()
+			}
+
+			ImGui.nextColumn()
+
+			// Rechte Seite: Ausgewählte Elemente
+			ImGui.text("Selected")
+			child("##${setting.name}-SelectedChild", childWidth, childHeight, ImGuiChildFlags.Border) {
+				selectedItems.filter { item ->
+					val q = searchFilter.trim()
+					if (q.isEmpty()) true
+					else item.toString().contains(q, ignoreCase = true)
+				}.forEach { item ->
+					val selected = item in modelSelected
+					if (ImGui.selectable("$item##selected", selected)) {
+						modelSelected.add(item)
+					}
+				}
+			}
+
+			ImGui.columns(1)
+
+			ImGui.separator()
+			val closeButtonWidth = 100f
+			val windowWidth = ImGui.getWindowWidth()
+			ImGui.setCursorPosX((windowWidth - closeButtonWidth) / 2f)
+			if (ImGui.button("Save", closeButtonWidth, 0f)) {
+				modelSelected.clear()
+				ImGui.closeCurrentPopup()
+			}
+
+			ImGui.endPopup()
+		}
+		if (!pOpen.get()) {
+			modelSelected.clear()
+		}
+
+		buildComboBox("item") { it.toString() }
+	}
 
 	context(setting: Setting<*, MutableCollection<R>>)
 	fun ImGuiBuilder.buildComboBox(itemName: String, toString: (R) -> String) {
@@ -106,11 +237,11 @@ open class CollectionSetting<R : Any>(
 	}
 
 	context(setting: Setting<*, MutableCollection<R>>)
-    override fun toJson(): JsonElement =
+	override fun toJson(): JsonElement =
 		gson.toJsonTree(value, type)
 
 	context(setting: Setting<*, MutableCollection<R>>)
-    override fun loadFromJson(serialized: JsonElement) {
+	override fun loadFromJson(serialized: JsonElement) {
 		val strList =
 			if (serialize) gson.fromJson(serialized, type)
 			else gson.fromJson<Collection<String>>(serialized, strListType)
@@ -129,10 +260,10 @@ open class CollectionSetting<R : Any>(
 			core.deselectListeners.add(block)
 		}
 
-        @SettingEditorDsl
-        @Suppress("unchecked_cast")
-        fun <T : Any> SettingGroupEditor.TypedEditBuilder<Collection<T>>.immutableCollection(collection: Collection<T>) {
-            (settings as Collection<CollectionSetting<T>>).forEach { it.immutableCollection = collection }
-        }
-    }
+		@SettingEditorDsl
+		@Suppress("unchecked_cast")
+		fun <T : Any> SettingGroupEditor.TypedEditBuilder<Collection<T>>.immutableCollection(collection: Collection<T>) {
+			(settings as Collection<CollectionSetting<T>>).forEach { it.immutableCollection = collection }
+		}
+	}
 }

--- a/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
@@ -63,26 +63,41 @@ open class CollectionSetting<R : Any>(
 	val deselectListeners = mutableListOf<SafeContext.(R) -> Unit>()
 
 	val modelSelected = mutableSetOf<R>()
+	val modelSelectedAdd = mutableSetOf<R>()
+	val modelSelectedRemove = mutableSetOf<R>()
 
 	context(setting: Setting<*, MutableCollection<R>>)
 	override fun ImGuiBuilder.buildLayout() {
-		val popupName = "${setting.name}##${setting.name}-CollectionSettingPopup"
+		buildPopupButtonAndModel("${setting.name}##${setting.name}-CollectionSettingPopup")
 
+		//		buildComboBox("item") { it.toString() }
+	}
+
+	/**
+	 * Builds a popup for editing the selection. It displays two lists side by side: available elements on the left and selected elements on the right.
+	 * Available elements represents all elements from the [immutableCollection] that are not currently in the setting's value, while
+	 * selected elements represents all elements selected in the [value] list.
+	 * Changes are only applied after the user clicks the "Save" button. When existing using the popup without saving changes are discarded.
+	 * Users can move items between the lists using ">>" and "<<" buttons. A search box allows filtering items in both lists. The popup also includes
+	 * "Select All" and "Clear Search" buttons for convenience.
+	 */
+	context(setting: Setting<*, MutableCollection<R>>)
+	private fun ImGuiBuilder.buildPopupButtonAndModel(popupName: String) {
 		val childWidth = 350f
 		val childHeight = 500f
 		val buttonColumnWidth = 60f
 		val totalWidth = (childWidth + 10f) * 2 + buttonColumnWidth + 20f
 		val totalHeight = childHeight + 190f
 
-		if (ImGui.button("Edit List##${setting.name}-Edit")) {
+		if (ImGui.button("${setting.name}: Edit Selection <${value.size} of ${immutableCollection.size} selected>##${setting.name}-Edit")) {
 			ImGui.openPopup(popupName)
 		}
 
 		ImGui.setNextWindowSize(totalWidth, totalHeight)
 		val pOpen = ImBoolean(true)
 		if (ImGui.beginPopupModal(popupName, pOpen, ImGuiWindowFlags.NoResize)) {
-			val availableItems = immutableCollection.filter { it !in value }
-			val selectedItems = value.toList()
+			val availableItems = (immutableCollection.filter { it !in value && it !in modelSelectedAdd } + modelSelectedRemove).toMutableSet()
+			val selectedItems = (value.toList() + modelSelectedAdd - modelSelectedRemove).toMutableSet()
 
 			inputText("##${setting.name}-SearchBox", ::searchFilter)
 			sameLine()
@@ -104,7 +119,7 @@ open class CollectionSetting<R : Any>(
 			ImGui.setColumnWidth(0, childWidth + 10f)
 			ImGui.setColumnWidth(1, buttonColumnWidth)
 
-			// Linke Seite: Verfügbare Elemente
+			// Left side: Available elements
 			ImGui.text("Values")
 			child("##${setting.name}-AvailableChild", childWidth, childHeight, ImGuiChildFlags.Border) {
 				availableItems.filter { item ->
@@ -121,7 +136,7 @@ open class CollectionSetting<R : Any>(
 
 			ImGui.nextColumn()
 
-			// Mittlere Spalte: Buttons
+			// Middle column: Buttons
 			ImGui.dummy(0f, 300f)
 			val columnWidth = ImGui.getColumnWidth()
 			val buttonWidth = 40f
@@ -134,10 +149,9 @@ open class CollectionSetting<R : Any>(
 						else item.toString().contains(q, ignoreCase = true)
 					}
 					.forEach { item ->
-					if (item in value) return@forEach
-					value.add(item)
-					runSafe { selectListeners.forEach { listener -> listener(item) } }
-				}
+						modelSelectedAdd.add(item)
+						modelSelectedRemove.remove(item)
+					}
 				modelSelected.clear()
 			}
 			ImGui.setCursorPosX(ImGui.getCursorPosX() + (columnWidth - buttonWidth) / 2f)
@@ -149,28 +163,28 @@ open class CollectionSetting<R : Any>(
 						else item.toString().contains(q, ignoreCase = true)
 					}
 					.forEach { item ->
-					if (item !in value) return@forEach
-					value.remove(item)
-					runSafe { deselectListeners.forEach { listener -> listener(item) } }
-				}
+						modelSelectedRemove.add(item)
+						modelSelectedAdd.remove(item)
+					}
 				modelSelected.clear()
 			}
 
 			ImGui.nextColumn()
 
-			// Rechte Seite: Ausgewählte Elemente
+			// Right side: Selected elements
 			ImGui.text("Selected")
 			child("##${setting.name}-SelectedChild", childWidth, childHeight, ImGuiChildFlags.Border) {
 				selectedItems.filter { item ->
 					val q = searchFilter.trim()
 					if (q.isEmpty()) true
 					else item.toString().contains(q, ignoreCase = true)
-				}.forEach { item ->
-					val selected = item in modelSelected
-					if (ImGui.selectable("$item##selected", selected)) {
-						modelSelected.add(item)
-					}
 				}
+					.forEach { item ->
+						val selected = item in modelSelected
+						if (ImGui.selectable("$item##selected", selected)) {
+							modelSelected.add(item)
+						}
+					}
 			}
 
 			ImGui.columns(1)
@@ -180,17 +194,30 @@ open class CollectionSetting<R : Any>(
 			val windowWidth = ImGui.getWindowWidth()
 			ImGui.setCursorPosX((windowWidth - closeButtonWidth) / 2f)
 			if (ImGui.button("Save", closeButtonWidth, 0f)) {
+				modelSelectedAdd.forEach { item ->
+					if (item !in value) {
+						value.add(item)
+						runSafe { selectListeners.forEach { listener -> listener(item) } }
+					}
+				}
+				modelSelectedRemove.forEach { item ->
+					if (item in value) {
+						value.remove(item)
+						runSafe { deselectListeners.forEach { listener -> listener(item) } }
+					}
+				}
 				modelSelected.clear()
+				modelSelectedRemove.clear()
+				modelSelectedAdd.clear()
 				ImGui.closeCurrentPopup()
 			}
 
 			ImGui.endPopup()
-		}
-		if (!pOpen.get()) {
+		} else {
 			modelSelected.clear()
+			modelSelectedRemove.clear()
+			modelSelectedAdd.clear()
 		}
-
-		buildComboBox("item") { it.toString() }
 	}
 
 	context(setting: Setting<*, MutableCollection<R>>)

--- a/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
@@ -51,6 +51,7 @@ open class CollectionSetting<R : Any>(
 	private var immutableCollection: Collection<R>,
 	type: Type,
 	private val serialize: Boolean,
+	val selectionModel: Boolean = false
 ) : SettingCore<MutableCollection<R>>(
 	defaultValue,
 	type
@@ -71,7 +72,11 @@ open class CollectionSetting<R : Any>(
 		val showReset = setting.isModified
 		val resetButtonText = "R"
 
-		buildPopupButtonAndModel("${setting.name}##${setting.name}-CollectionSettingPopup")
+		if (selectionModel) {
+			buildPopupButtonAndModel("${setting.name}##${setting.name}-CollectionSettingPopup")
+		} else {
+			buildComboBox("item") { it.toString() }
+		}
 
 		if (showReset) {
 			sameLine()

--- a/src/main/kotlin/com/lambda/module/modules/client/SelectionTest.kt
+++ b/src/main/kotlin/com/lambda/module/modules/client/SelectionTest.kt
@@ -26,5 +26,6 @@ class SelectionTest : Module(
 	tag = ModuleTag.CLIENT
 ) {
 
-	var selection1 by setting("Selection 1", listOf(), listOf("String 1", "String 2", "String 3"))
+	var selection1 by setting("Selection 1", listOf(), listOf("String 1", "String 2", "String 3"), selectionModel = false)
+	var selection2 by setting("Selection 2", listOf(), listOf("String 1", "String 2", "String 3"), selectionModel = true)
 }

--- a/src/main/kotlin/com/lambda/module/modules/client/SelectionTest.kt
+++ b/src/main/kotlin/com/lambda/module/modules/client/SelectionTest.kt
@@ -26,5 +26,5 @@ class SelectionTest : Module(
 	tag = ModuleTag.CLIENT
 ) {
 
-	var selection1 by setting("Selection 1", mutableListOf<String>(), mutableListOf("String 1", "String 2", "String 3"))
+	var selection1 by setting("Selection 1", listOf(), listOf("String 1", "String 2", "String 3"))
 }

--- a/src/main/kotlin/com/lambda/module/modules/client/SelectionTest.kt
+++ b/src/main/kotlin/com/lambda/module/modules/client/SelectionTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Lambda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.lambda.module.modules.client
+
+import com.lambda.module.Module
+import com.lambda.module.tag.ModuleTag
+
+class SelectionTest : Module(
+	name="SelectionTest",
+	description="",
+	tag = ModuleTag.CLIENT
+) {
+
+	var selection1 by setting("Selection 1", mutableListOf<String>(), mutableListOf("String 1", "String 2", "String 3"))
+}


### PR DESCRIPTION
Adds a popup model to select items from. It should be a lot easier to work with than having to scroll through the dropdown list.

<img width="822" height="719" alt="image of the List selection popup model featuring two selection menues to select entries from" src="https://github.com/user-attachments/assets/283ab01e-f018-47de-90bf-15baf228412b" />

You can make selections on either side of item lists and then change the side of the selected items with the arrow buttons. The "X" next to the search bar clears the search entry. "Select all" selects all currently visible items. The search field does not auto-clear when the model closes. This is intended behavior.

Code is kinda popo atm. I'll have to figure out some better ways to create the model window.