### PR TITLE
Fix - KillAura cannot target projectiles and other non-LivingEntities.

### DIFF
--- a/src/main/kotlin/com/lambda/config/groups/Targeting.kt
+++ b/src/main/kotlin/com/lambda/config/groups/Targeting.kt
@@ -105,7 +105,7 @@ abstract class Targeting(
          * Validates whether a given entity is targetable for combat based on the field of view limit and other settings.
          *
          * @param player The [ClientPlayerEntity] performing the targeting.
-         * @param entity The [LivingEntity] being evaluated.
+         * @param entity The [Entity] being evaluated.
          * @return `true` if the entity is valid for targeting, `false` otherwise.
          */
         override fun validate(player: ClientPlayerEntity, entity: Entity): Boolean {

--- a/src/main/kotlin/com/lambda/config/groups/Targeting.kt
+++ b/src/main/kotlin/com/lambda/config/groups/Targeting.kt
@@ -149,7 +149,7 @@ abstract class Targeting(
 
         /**
          * Prioritizes entities based on their health.
-         * Entites that aren't an instanceof LivingEntity will be treated as if they have Double.MAX_VALUE health,
+         * Entities that aren't an instanceof LivingEntity will be treated as if they have Double.MAX_VALUE health,
          * therefore having least priority
          */
         Health({ (it as? LivingEntity)?.fullHealth ?: Double.MAX_VALUE }),

--- a/src/main/kotlin/com/lambda/config/groups/Targeting.kt
+++ b/src/main/kotlin/com/lambda/config/groups/Targeting.kt
@@ -26,15 +26,13 @@ import com.lambda.interaction.managers.rotating.Rotation.Companion.dist
 import com.lambda.interaction.managers.rotating.Rotation.Companion.rotation
 import com.lambda.interaction.managers.rotating.Rotation.Companion.rotationTo
 import com.lambda.threading.runSafe
-import com.lambda.util.EntityUtils.EntityGroup
-import com.lambda.util.EntityUtils.entityGroup
 import com.lambda.util.NamedEnum
 import com.lambda.util.extension.fullHealth
 import com.lambda.util.math.distSq
 import com.lambda.util.world.fastEntitySearch
 import net.minecraft.client.network.ClientPlayerEntity
 import net.minecraft.client.network.OtherClientPlayerEntity
-import net.minecraft.client.toast.SystemToast.hide
+import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
 import java.util.*
 
@@ -76,7 +74,7 @@ abstract class Targeting(
 	 * @param entity The [LivingEntity] being evaluated.
 	 * @return `true` if the entity is valid for targeting, `false` otherwise.
 	 */
-    open fun validate(player: ClientPlayerEntity, entity: LivingEntity) =
+    open fun validate(player: ClientPlayerEntity, entity: Entity) =
 		targets.isSelected(entity) && (entity !is OtherClientPlayerEntity || !entity.isFriend)
 
     /**
@@ -110,20 +108,20 @@ abstract class Targeting(
          * @param entity The [LivingEntity] being evaluated.
          * @return `true` if the entity is valid for targeting, `false` otherwise.
          */
-        override fun validate(player: ClientPlayerEntity, entity: LivingEntity): Boolean {
+        override fun validate(player: ClientPlayerEntity, entity: Entity): Boolean {
             if (fov < 180 && player.rotation dist player.eyePos.rotationTo(entity.pos) > fov) return false
             if (entity.uuid in illegalTargets) return false
-            if (entity.isDead) return false
+	        if ((entity as? LivingEntity)?.isDead == true) return false
             return super.validate(player, entity)
         }
 
         /**
          * Gets the best target for combat based on the current settings and priority.
          *
-         * @return The best [LivingEntity] target, or `null` if no valid target is found.
+         * @return The best [Entity] target, or `null` if no valid target is found.
          */
-        fun target(): LivingEntity? = runSafe {
-            return@runSafe fastEntitySearch<LivingEntity>(targetingRange) {
+        inline fun <reified T : Entity> target(): T? = runSafe {
+            return@runSafe fastEntitySearch<T>(targetingRange) {
                 validate(player, it)
             }.minByOrNull {
                 priority.factor(this, it)
@@ -140,10 +138,10 @@ abstract class Targeting(
     /**
      * Enum representing the different priority factors used for determining the best target.
      *
-     * @property factor A lambda function that calculates the priority factor for a given [LivingEntity].
+     * @property factor A lambda function that calculates the priority factor for a given [Entity].
      */
     @Suppress("Unused")
-    enum class Priority(val factor: SafeContext.(LivingEntity) -> Double) {
+    enum class Priority(val factor: SafeContext.(Entity) -> Double) {
         /**
          * Prioritizes entities based on their distance from the player.
          */
@@ -151,8 +149,10 @@ abstract class Targeting(
 
         /**
          * Prioritizes entities based on their health.
+         * Entites that aren't an instanceof LivingEntity will be treated as if they are at 0 health,
+         * therefore having least priority
          */
-        Health({ it.fullHealth }),
+        Health({ (it as? LivingEntity)?.fullHealth ?: 0.0 }),
 
         /**
          * Prioritizes entities based on their angle relative to the player's field of view.

--- a/src/main/kotlin/com/lambda/config/groups/Targeting.kt
+++ b/src/main/kotlin/com/lambda/config/groups/Targeting.kt
@@ -149,10 +149,10 @@ abstract class Targeting(
 
         /**
          * Prioritizes entities based on their health.
-         * Entites that aren't an instanceof LivingEntity will be treated as if they are at 0 health,
+         * Entites that aren't an instanceof LivingEntity will be treated as if they have Double.MAX_VALUE health,
          * therefore having least priority
          */
-        Health({ (it as? LivingEntity)?.fullHealth ?: 0.0 }),
+        Health({ (it as? LivingEntity)?.fullHealth ?: Double.MAX_VALUE }),
 
         /**
          * Prioritizes entities based on their angle relative to the player's field of view.

--- a/src/main/kotlin/com/lambda/module/modules/combat/CrystalAura.kt
+++ b/src/main/kotlin/com/lambda/module/modules/combat/CrystalAura.kt
@@ -245,7 +245,7 @@ object CrystalAura : Module(
 
     private fun SafeContext.tick() {
         // Update the target
-        currentTarget = targeting.target()
+        currentTarget = targeting.target<LivingEntity>()
 
         // Update the blueprint
         currentTarget?.let {

--- a/src/main/kotlin/com/lambda/module/modules/combat/KillAura.kt
+++ b/src/main/kotlin/com/lambda/module/modules/combat/KillAura.kt
@@ -36,7 +36,7 @@ import com.lambda.util.item.ItemStackUtils.attackDamage
 import com.lambda.util.item.ItemStackUtils.attackSpeed
 import com.lambda.util.math.random
 import com.lambda.util.player.SlotUtils.hotbarStacks
-import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.Entity
 import net.minecraft.item.ItemStack
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket
 import net.minecraft.util.Hand
@@ -59,8 +59,8 @@ object KillAura : Module(
     // Targeting
     private val targeting = Targeting.Combat(c = this, baseGroup = arrayOf(Group.Targeting))
 
-    val target: LivingEntity?
-        get() = targeting.target()
+    val target: Entity?
+        get() = targeting.target<Entity>()
 
     private var prevEntity = target
     private var validServerRot = false

--- a/src/main/kotlin/com/lambda/module/modules/movement/BackTrack.kt
+++ b/src/main/kotlin/com/lambda/module/modules/movement/BackTrack.kt
@@ -95,7 +95,7 @@ object BackTrack : Module(
     init {
         listen<TickEvent.Pre> {
             val prevTarget = target
-            target = if (KillAura.isDisabled) null else KillAura.target
+            target = KillAura.target.takeIf { KillAura.isEnabled } as? LivingEntity
             val currentTarget = target
 
             if (prevTarget != currentTarget || currentTarget == null) {


### PR DESCRIPTION
Previously lambda's killaura was unable to target and hit projectiles, like shulker bullets, despite having the ability to select them as a target. This is because `Targeting.target()` would only ever give you a `LivingEntity`, below is the original code for `Targeting.target()`:

```kt
fun target(): LivingEntity? = runSafe {
    return@runSafe fastEntitySearch<LivingEntity>(targetingRange) {
    // 5 lines not shown...
```

This is changed in my pull to accept a `T : Entity` generic during the call, so that in `KillAura.kt`:
```kt
val target: LivingEntity?
    get() = targeting.target()
```
becomes
```kt
val target: Entity?
    get() = targeting.target<Entity>()
```
This allows more flexibility in the use of the targeting system, and allows `CrystalAura.kt` to remain unaffected by this change, it'll still only target for a LivingEntity:
```kt
private fun SafeContext.tick() {
    // Update the target
    currentTarget = targeting.target<LivingEntity>()
```

some minor modifications to `Targeting.validate()` and `Targeting.Priority` were made to accommodate a generic `Entity` object