### PR TITLE
Fix Y coordinate limits on BlockPosSetting command

### DIFF
--- a/src/main/kotlin/com/lambda/config/settings/complex/BlockPosSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/complex/BlockPosSetting.kt
@@ -46,7 +46,7 @@ class BlockPosSetting(defaultValue: BlockPos) : SettingCore<BlockPos>(
 	context(setting: Setting<*, BlockPos>)
     override fun CommandBuilder.buildCommand(registry: CommandRegistryAccess) {
         required(integer("X", -30000000, 30000000)) { x ->
-            required(integer("Y", -64, 255)) { y ->
+            required(integer("Y", -64, 319)) { y ->
                 required(integer("Z", -30000000, 30000000)) { z ->
                     execute {
                         setting.trySetValue(BlockPos(x().value(), y().value(), z().value()))


### PR DESCRIPTION
The max Y level that can be built at in Minecraft 1.21.11 is 319, not 255