### PR TITLE
fix(ContainerPreview): Fix invisible text on preview

### DIFF
--- a/src/main/kotlin/com/lambda/module/modules/render/ContainerPreview.kt
+++ b/src/main/kotlin/com/lambda/module/modules/render/ContainerPreview.kt
@@ -38,6 +38,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import net.minecraft.item.tooltip.TooltipData
 import net.minecraft.screen.slot.Slot
+import net.minecraft.util.Colors
 import net.minecraft.util.DyeColor
 import net.minecraft.util.Identifier
 
@@ -98,7 +99,7 @@ object ContainerPreview : Module(
         val g = ((tintColor shr 8) and 0xFF) / 255f
         val b = (tintColor and 0xFF) / 255f
         val luminance = 0.299f * r + 0.587f * g + 0.114f * b
-        return if (luminance > 0.5f) 0x404040 else 0xFFFFFF
+        return if (luminance > 0.7f) Colors.DARK_GRAY else Colors.WHITE
     }
 
     @JvmStatic


### PR DESCRIPTION
This pr changes the luminance method. It replaces the magic number values with the Minecraft internal color values. The used magic values had zero alpha components and thus appeared invisible.
This PR also changes the luminance check on the text color to make the text in the preview windows easier to read.

Luminance comparison
Before:
<img width="1777" height="730" alt="image" src="https://github.com/user-attachments/assets/733b227a-ac18-4849-84be-cb6bcff6325c" />
<img width="1650" height="486" alt="image" src="https://github.com/user-attachments/assets/7b6d5c40-5f12-4d72-8ff7-cd08722e97ab" />

After:
<img width="1768" height="646" alt="image" src="https://github.com/user-attachments/assets/8c57c96f-ffae-4704-8405-5bc88614313b" />
<img width="1671" height="609" alt="image" src="https://github.com/user-attachments/assets/fd477bb3-4c8d-4736-b7e0-e1dda14bf29a" />



