### PR TITLE
feat(Printer): Add flattenMode and baritone selection to printer module

### DIFF
--- a/src/main/kotlin/com/lambda/interaction/construction/blueprint/TickingBlueprint.kt
+++ b/src/main/kotlin/com/lambda/interaction/construction/blueprint/TickingBlueprint.kt
@@ -18,12 +18,15 @@
 package com.lambda.interaction.construction.blueprint
 
 import com.lambda.context.SafeContext
+import com.lambda.interaction.construction.simulation.result.BuildResult
 import com.lambda.threading.runSafe
 import com.lambda.util.extension.Structure
 import net.minecraft.util.math.Vec3i
+import java.util.function.Predicate
 
 data class TickingBlueprint(
-    val onTick: SafeContext.(Structure) -> Structure? = { it },
+    val buildResultPredicate: Predicate<BuildResult> = Predicate { true },
+    val onTick: SafeContext.(Structure) -> Structure? = { it }
 ) : Blueprint() {
     fun tick() =
         runSafe {
@@ -49,6 +52,6 @@ data class TickingBlueprint(
 
         fun tickingBlueprint(
             onTick: SafeContext.(Structure) -> Structure?,
-        ) = TickingBlueprint(onTick)
+        ) = TickingBlueprint(onTick = onTick)
     }
 }

--- a/src/main/kotlin/com/lambda/interaction/construction/blueprint/TickingBlueprint.kt
+++ b/src/main/kotlin/com/lambda/interaction/construction/blueprint/TickingBlueprint.kt
@@ -25,7 +25,7 @@ import net.minecraft.util.math.Vec3i
 import java.util.function.Predicate
 
 data class TickingBlueprint(
-    val buildResultPredicate: Predicate<BuildResult> = Predicate { true },
+    val buildResultPredicate: SafeContext.(BuildResult) -> Boolean = { true },
     val onTick: SafeContext.(Structure) -> Structure? = { it }
 ) : Blueprint() {
     fun tick() =
@@ -51,7 +51,8 @@ data class TickingBlueprint(
         }
 
         fun tickingBlueprint(
-            onTick: SafeContext.(Structure) -> Structure?,
-        ) = TickingBlueprint(onTick = onTick)
+            buildResultPredicate: SafeContext.(BuildResult) -> Boolean = { true },
+            onTick: SafeContext.(Structure) -> Structure?
+        ) = TickingBlueprint(onTick = onTick, buildResultPredicate = buildResultPredicate)
     }
 }

--- a/src/main/kotlin/com/lambda/interaction/construction/blueprint/TickingBlueprint.kt
+++ b/src/main/kotlin/com/lambda/interaction/construction/blueprint/TickingBlueprint.kt
@@ -18,14 +18,11 @@
 package com.lambda.interaction.construction.blueprint
 
 import com.lambda.context.SafeContext
-import com.lambda.interaction.construction.simulation.result.BuildResult
 import com.lambda.threading.runSafe
 import com.lambda.util.extension.Structure
 import net.minecraft.util.math.Vec3i
-import java.util.function.Predicate
 
 data class TickingBlueprint(
-    val buildResultPredicate: SafeContext.(BuildResult) -> Boolean = { true },
     val onTick: SafeContext.(Structure) -> Structure? = { it }
 ) : Blueprint() {
     fun tick() =
@@ -51,8 +48,7 @@ data class TickingBlueprint(
         }
 
         fun tickingBlueprint(
-            buildResultPredicate: SafeContext.(BuildResult) -> Boolean = { true },
             onTick: SafeContext.(Structure) -> Structure?
-        ) = TickingBlueprint(onTick = onTick, buildResultPredicate = buildResultPredicate)
+        ) = TickingBlueprint(onTick)
     }
 }

--- a/src/main/kotlin/com/lambda/module/modules/world/Nuker.kt
+++ b/src/main/kotlin/com/lambda/module/modules/world/Nuker.kt
@@ -20,8 +20,6 @@ package com.lambda.module.modules.world
 import com.lambda.config.AutomationConfig.Companion.setDefaultAutomationConfig
 import com.lambda.config.applyEdits
 import com.lambda.context.SafeContext
-import com.lambda.interaction.BaritoneManager
-import com.lambda.interaction.construction.blueprint.TickingBlueprint
 import com.lambda.interaction.construction.blueprint.TickingBlueprint.Companion.tickingBlueprint
 import com.lambda.interaction.construction.verify.TargetState
 import com.lambda.module.Module
@@ -30,12 +28,11 @@ import com.lambda.task.RootTask.run
 import com.lambda.task.Task
 import com.lambda.task.tasks.BuildTask.Companion.build
 import com.lambda.util.BlockUtils.blockPos
-import com.lambda.util.BlockUtils.blockState
-import com.lambda.util.BlockUtils.isNotEmpty
-import com.lambda.util.math.MathUtils.ceilToInt
 import net.minecraft.block.Blocks
 import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.Direction
+import com.lambda.util.PlayerBuildLayerUtils.FlattenMode
+import com.lambda.util.PlayerBuildLayerUtils.isInFlatten
+import com.lambda.util.PlayerBuildLayerUtils.isInBaritoneSelection
 
 object Nuker : Module(
 	name = "Nuker",
@@ -72,9 +69,9 @@ object Nuker : Module(
 					.asSequence()
 					.map { it.blockPos }
 					.filter { !world.isAir(it) }
-					.filter { flattenMode == FlattenMode.None || isInFlatten(it) }
+					.filter { flattenMode == FlattenMode.None || isInFlatten(it, flattenMode, sneakLowersFlatten, baritoneSelection, false) }
 					.filter { isWithinDigDirection(it) }
-					.filter { isInBaritoneSelection(it) == !inverseSelection }
+					.filter { !baritoneSelection || isInBaritoneSelection(it) == !inverseSelection }
 					.associateWith { if (breakConfig.fillFluids) TargetState.Air else TargetState.Empty }
 
 				if (fillFloor) {
@@ -94,43 +91,6 @@ object Nuker : Module(
 		}
 	}
 
-	private fun SafeContext.isInFlatten(pos: BlockPos): Boolean {
-		if (flattenMode == FlattenMode.Staircase) {
-			val up = pos.up()
-			if ((blockState(up).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up)))
-				|| (blockState(up.east()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.east())))
-				|| (blockState(up.south()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.south())))
-				|| (blockState(up.west()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.west())))
-				|| (blockState(up.north()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.north())))
-			)  { return false }
-		}
-
-		val flattenY = player.y.ceilToInt()
-		val playerPos = player.blockPos
-		val flattenLevel =
-			if (sneakLowersFlatten && player.isSneaking) flattenY - 1
-			else flattenY
-
-		if (!flattenMode.isSmart && pos.y < flattenLevel)
-			return false
-
-		if (pos == player.supportingBlockPos) return false
-
-		val playerLookDir = player.horizontalFacing
-		val smartFlattenDir =
-			if (flattenMode == FlattenMode.Smart) playerLookDir
-			else playerLookDir?.opposite
-
-		if (pos.y >= flattenLevel) return true
-
-		val zeroedPos = pos.add(-playerPos.x, -flattenY, -playerPos.z)
-
-		return (zeroedPos.x < 0 && smartFlattenDir == Direction.EAST)
-				|| (zeroedPos.z < 0 && smartFlattenDir == Direction.SOUTH)
-				|| (zeroedPos.x > 0 && smartFlattenDir == Direction.WEST)
-				|| (zeroedPos.z > 0 && smartFlattenDir == Direction.NORTH)
-	}
-
 	private fun SafeContext.isWithinDigDirection(pos: BlockPos): Boolean {
 		val playerPos = player.blockPos
 		return when (directionalDig) {
@@ -140,27 +100,6 @@ object Nuker : Module(
 			DigDirection.North -> playerPos.z >= pos.z
 			DigDirection.South -> playerPos.z <= pos.z
 		}
-	}
-
-	private fun isInBaritoneSelection(pos: BlockPos) =
-		if (!baritoneSelection) true
-		else BaritoneManager.primary?.selectionManager?.selections?.any {
-			val min = it.min()
-			val max = it.max()
-			pos.x >= min.x && pos.x <= max.x
-					&& pos.y >= min.y && pos.y <= max.y
-					&& pos.z >= min.z && pos.z <= max.z
-		} ?: false
-
-	private enum class FlattenMode {
-		None,
-		Standard,
-		Smart,
-		ReverseSmart,
-		Staircase;
-
-		val isSmart
-			get() = this == Smart || this == ReverseSmart
 	}
 
 	private enum class DigDirection {

--- a/src/main/kotlin/com/lambda/module/modules/world/Nuker.kt
+++ b/src/main/kotlin/com/lambda/module/modules/world/Nuker.kt
@@ -66,12 +66,12 @@ object Nuker : Module(
 				if (onGround && !player.isOnGround) return@tickingBlueprint emptyMap()
 
 				val selection = BlockPos.iterateOutwards(player.blockPos, width, height, width)
-					.asSequence()
 					.map { it.blockPos }
+					.asSequence()
 					.filter { !world.isAir(it) }
-					.filter { flattenMode == FlattenMode.None || isInFlatten(it, flattenMode, sneakLowersFlatten, baritoneSelection, false) }
+					.filter { !baritoneSelection || isInBaritoneSelection(it) != inverseSelection }
+					.filter { isInFlatten(it, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection) }
 					.filter { isWithinDigDirection(it) }
-					.filter { !baritoneSelection || isInBaritoneSelection(it) == !inverseSelection }
 					.associateWith { if (breakConfig.fillFluids) TargetState.Air else TargetState.Empty }
 
 				if (fillFloor) {

--- a/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
+++ b/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
@@ -21,6 +21,9 @@ import com.lambda.config.AutomationConfig.Companion.setDefaultAutomationConfig
 import com.lambda.context.SafeContext
 import com.lambda.interaction.BaritoneManager
 import com.lambda.interaction.construction.blueprint.TickingBlueprint
+import com.lambda.interaction.construction.simulation.result.BuildResult
+import com.lambda.interaction.construction.simulation.result.results.BreakResult
+import com.lambda.interaction.construction.simulation.result.results.InteractResult
 import com.lambda.interaction.construction.verify.TargetState
 import com.lambda.module.Module
 import com.lambda.module.tag.ModuleTag
@@ -63,24 +66,50 @@ object Printer : Module(
 				disable()
 				return@onEnable
 			}
-			buildTask = TickingBlueprint {
+			buildTask = TickingBlueprint(onTick = {
 				val schematicWorld = SchematicWorldHandler.getSchematicWorld() ?: return@TickingBlueprint emptyMap()
 				BlockPos.iterateOutwards(player.blockPos, range, range, range)
 					.map { it.blockPos }
 					.asSequence()
 					.filter { DataManager.getRenderLayerRange().isPositionWithinRange(it) && inSchematic(it) }
 					.associateWith { TargetState.State(schematicWorld.getBlockState(it)) }
-					.filter {
-						if (flattenModeApply == FlattenModeApply.PlaceOnly && it.value.blockState.isAir) return@filter true
-						if (flattenModeApply == FlattenModeApply.BreakOnly && !it.value.blockState.isAir) return@filter true
-						return@filter isInFlatten(it.key)
-					}
-					.filterNot { isInBaritoneSelection(it.key) == inverseSelection }
 					.filter { air || !it.value.blockState.isAir }
-			}.build(finishOnDone = false).run()
+			}, buildResultPredicate = { filterBuildResults(it) }).build(finishOnDone = false).run()
 		}
 
 		onDisable { buildTask?.cancel(); buildTask = null }
+	}
+
+	/**
+	 * Checks a block position against the current settings to determine whether a build result at that position should be considered for building.
+	 *
+	 * @return true if the build result should be built, false if it should be ignored
+	 */
+	private fun SafeContext.filterBuildResults(buildResult: BuildResult): Boolean {
+		if (baritoneSelection) {
+			val inSelection = isInBaritoneSelection(buildResult.pos)
+			if (inverseSelection && inSelection) return false
+			if (!inverseSelection && !inSelection) return false
+		}
+
+		if (flattenModeApply == FlattenModeApply.Both) {
+			return isInFlatten(buildResult.pos)
+		}
+		return when (buildResult) {
+			is InteractResult.Interact -> {
+				if (flattenModeApply != FlattenModeApply.PlaceOnly) {
+					return true
+				}
+				isInFlatten(buildResult.pos)
+			}
+			is BreakResult.Break -> {
+				if (flattenModeApply != FlattenModeApply.BreakOnly) {
+					return true
+				}
+				isInFlatten(buildResult.pos)
+			}
+			else -> true
+		}
 	}
 
 	private fun inSchematic(pos: BlockPos): Boolean {

--- a/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
+++ b/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
@@ -19,8 +19,9 @@ package com.lambda.module.modules.world
 
 import com.lambda.config.AutomationConfig.Companion.setDefaultAutomationConfig
 import com.lambda.context.SafeContext
-import com.lambda.interaction.construction.blueprint.TickingBlueprint
+import com.lambda.interaction.construction.blueprint.TickingBlueprint.Companion.tickingBlueprint
 import com.lambda.interaction.construction.simulation.result.BuildResult
+import com.lambda.interaction.construction.simulation.result.Contextual
 import com.lambda.interaction.construction.simulation.result.results.BreakResult
 import com.lambda.interaction.construction.simulation.result.results.InteractResult
 import com.lambda.interaction.construction.verify.TargetState
@@ -65,15 +66,16 @@ object Printer : Module(
 				disable()
 				return@onEnable
 			}
-			buildTask = TickingBlueprint(buildResultPredicate = { filterBuildResults(it) }) {
-				val schematicWorld = SchematicWorldHandler.getSchematicWorld() ?: return@TickingBlueprint emptyMap()
+			buildTask = tickingBlueprint {
+				val schematicWorld = SchematicWorldHandler.getSchematicWorld() ?: return@tickingBlueprint emptyMap()
 				BlockPos.iterateOutwards(player.blockPos, range, range, range)
 					.map { it.blockPos }
 					.asSequence()
+					.filter { pos -> !baritoneSelection || isInBaritoneSelection(pos) != inverseSelection }
 					.filter { DataManager.getRenderLayerRange().isPositionWithinRange(it) && inSchematic(it) }
 					.associateWith { TargetState.State(schematicWorld.getBlockState(it)) }
 					.filter { air || !it.value.blockState.isAir }
-			}.build(finishOnDone = false).run()
+			}.build(finishOnDone = false, buildResultFilter = { filterBuildResults(it) }).run()
 		}
 
 		onDisable { buildTask?.cancel(); buildTask = null }
@@ -85,24 +87,10 @@ object Printer : Module(
 	 * @return true if the build result should be built, false if it should be ignored
 	 */
 	private fun SafeContext.filterBuildResults(buildResult: BuildResult): Boolean {
-		val inSelection = isInBaritoneSelection(buildResult.pos)
-		if (inverseSelection && inSelection) return false
-		if (!inverseSelection && !inSelection) return false
-
-		if (flattenModeApply == FlattenModeApply.Both) {
-			return isInFlatten(buildResult.pos, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection)
-		}
-		return when (buildResult) {
-			is InteractResult.Interact -> {
-				if (flattenModeApply != FlattenModeApply.PlaceOnly) true
-				else isInFlatten(buildResult.pos, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection)
-			}
-			is BreakResult.Break -> {
-				if (flattenModeApply != FlattenModeApply.BreakOnly) true
-				else isInFlatten(buildResult.pos, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection)
-			}
-			else -> true
-		}
+		return if (buildResult !is Contextual ||
+			buildResult is InteractResult && !flattenModeApply.placing ||
+			buildResult is BreakResult && !flattenModeApply.breaking) true
+		else isInFlatten(buildResult.pos, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection)
 	}
 
 	private fun litematicaAvailable(): Boolean = runCatching {
@@ -112,10 +100,12 @@ object Printer : Module(
 
 	private enum class FlattenModeApply(
 		override val displayName: String,
+		val breaking: Boolean,
+		val placing: Boolean,
 		override val description: String
 	) : NamedEnum, Describable {
-		BreakOnly("Break Only", "Only applies flattening logic to blocks that are being broken"),
-		PlaceOnly("Place Only", "Only applies flattening logic to blocks that are being placed"),
-		Both("Both", "Applies flattening logic to all blocks, whether being placed or broken")
+		BreakOnly("Break Only", true, false, "Only applies flattening logic to blocks that are being broken"),
+		PlaceOnly("Place Only", false, true, "Only applies flattening logic to blocks that are being placed"),
+		Both("Both", true, true, "Applies flattening logic to all blocks, whether being placed or broken")
 	}
 }

--- a/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
+++ b/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
@@ -18,6 +18,8 @@
 package com.lambda.module.modules.world
 
 import com.lambda.config.AutomationConfig.Companion.setDefaultAutomationConfig
+import com.lambda.context.SafeContext
+import com.lambda.interaction.BaritoneManager
 import com.lambda.interaction.construction.blueprint.TickingBlueprint
 import com.lambda.interaction.construction.verify.TargetState
 import com.lambda.module.Module
@@ -26,10 +28,16 @@ import com.lambda.task.RootTask.run
 import com.lambda.task.Task
 import com.lambda.task.tasks.BuildTask.Companion.build
 import com.lambda.util.BlockUtils.blockPos
+import com.lambda.util.BlockUtils.blockState
+import com.lambda.util.BlockUtils.isNotEmpty
 import com.lambda.util.Communication.logError
+import com.lambda.util.Describable
+import com.lambda.util.NamedEnum
+import com.lambda.util.math.MathUtils.ceilToInt
 import fi.dy.masa.litematica.data.DataManager
 import fi.dy.masa.litematica.world.SchematicWorldHandler
 import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Direction
 
 object Printer : Module(
 	name = "Printer",
@@ -38,6 +46,11 @@ object Printer : Module(
 ) {
 	private val range by setting("Range", 5, 1..7, 1, description = "The range around the player to check for blocks to print")
 	private val air by setting("Air", false, description = "Consider breaking blocks in the world that are air in the schematic.\nNote: Breaking can also be disabled in the Automation Config.")
+	private val flattenMode by setting("Flatten Mode", FlattenMode.Standard, description = "Configures what blocks to break relative to the player's Y level")
+	private val flattenModeApply by setting("Flatten Apply Mode", FlattenModeApply.BreakOnly, description = "Configures whether the flatten mode applies to breaking, placing, or both") { flattenMode != FlattenMode.None }
+	private val baritoneSelection by setting("Baritone Selection", false, "Restricts block breaking and placing to your baritone selection")
+	private val inverseSelection by setting("Inverse Selection", false, "Break and place blocks outside of the baritone selection and ignores blocks inside") { baritoneSelection }
+	private val sneakLowersFlatten by setting("Sneak Lowers Flatten", false, "When enabled, sneaking will lower the flattening level by 1, allowing you to mine the block below you")
 
 	private var buildTask: Task<*>? = null
 
@@ -57,6 +70,12 @@ object Printer : Module(
 					.asSequence()
 					.filter { DataManager.getRenderLayerRange().isPositionWithinRange(it) && inSchematic(it) }
 					.associateWith { TargetState.State(schematicWorld.getBlockState(it)) }
+					.filter {
+						if (flattenModeApply == FlattenModeApply.PlaceOnly && it.value.blockState.isAir) return@filter true
+						if (flattenModeApply == FlattenModeApply.BreakOnly && !it.value.blockState.isAir) return@filter true
+						return@filter isInFlatten(it.key)
+					}
+					.filterNot { isInBaritoneSelection(it.key) == inverseSelection }
 					.filter { air || !it.value.blockState.isAir }
 			}.build(finishOnDone = false).run()
 		}
@@ -75,4 +94,74 @@ object Printer : Module(
 		Class.forName("fi.dy.masa.litematica.Litematica")
 		true
 	}.getOrDefault(false)
+
+	private fun SafeContext.isInFlatten(pos: BlockPos): Boolean {
+		if (flattenMode == FlattenMode.None) return true
+		if (flattenMode == FlattenMode.Staircase) {
+			val up = pos.up()
+			if ((blockState(up).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up)))
+				|| (blockState(up.east()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.east())))
+				|| (blockState(up.south()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.south())))
+				|| (blockState(up.west()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.west())))
+				|| (blockState(up.north()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.north())))
+			) {
+				return false
+			}
+		}
+
+		val flattenY = player.y.ceilToInt()
+		val playerPos = player.blockPos
+		val flattenLevel =
+			if (sneakLowersFlatten && player.isSneaking) flattenY - 1
+			else flattenY
+
+		if (!flattenMode.isSmart && pos.y < flattenLevel)
+			return false
+
+		if (pos == player.supportingBlockPos) return false
+
+		val playerLookDir = player.horizontalFacing
+		val smartFlattenDir =
+			if (flattenMode == FlattenMode.Smart) playerLookDir
+			else playerLookDir?.opposite
+
+		if (pos.y >= flattenLevel) return true
+
+		val zeroedPos = pos.add(-playerPos.x, -flattenY, -playerPos.z)
+
+		return (zeroedPos.x < 0 && smartFlattenDir == Direction.EAST)
+				|| (zeroedPos.z < 0 && smartFlattenDir == Direction.SOUTH)
+				|| (zeroedPos.x > 0 && smartFlattenDir == Direction.WEST)
+				|| (zeroedPos.z > 0 && smartFlattenDir == Direction.NORTH)
+	}
+
+	private fun isInBaritoneSelection(pos: BlockPos) =
+		if (!baritoneSelection) true
+		else BaritoneManager.primary?.selectionManager?.selections?.any {
+			val min = it.min()
+			val max = it.max()
+			pos.x >= min.x && pos.x <= max.x
+					&& pos.y >= min.y && pos.y <= max.y
+					&& pos.z >= min.z && pos.z <= max.z
+		} ?: false
+
+	private enum class FlattenMode {
+		None,
+		Standard,
+		Smart,
+		ReverseSmart,
+		Staircase;
+
+		val isSmart
+			get() = this == Smart || this == ReverseSmart
+	}
+
+	private enum class FlattenModeApply(
+		override val displayName: String,
+		override val description: String
+	) : NamedEnum, Describable {
+		BreakOnly("Break Only", "Only applies flattening logic to blocks that are being broken"),
+		PlaceOnly("Place Only", "Only applies flattening logic to blocks that are being placed"),
+		Both("Both", "Applies flattening logic to all blocks, whether being placed or broken")
+	}
 }

--- a/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
+++ b/src/main/kotlin/com/lambda/module/modules/world/Printer.kt
@@ -19,7 +19,6 @@ package com.lambda.module.modules.world
 
 import com.lambda.config.AutomationConfig.Companion.setDefaultAutomationConfig
 import com.lambda.context.SafeContext
-import com.lambda.interaction.BaritoneManager
 import com.lambda.interaction.construction.blueprint.TickingBlueprint
 import com.lambda.interaction.construction.simulation.result.BuildResult
 import com.lambda.interaction.construction.simulation.result.results.BreakResult
@@ -31,16 +30,16 @@ import com.lambda.task.RootTask.run
 import com.lambda.task.Task
 import com.lambda.task.tasks.BuildTask.Companion.build
 import com.lambda.util.BlockUtils.blockPos
-import com.lambda.util.BlockUtils.blockState
-import com.lambda.util.BlockUtils.isNotEmpty
 import com.lambda.util.Communication.logError
 import com.lambda.util.Describable
 import com.lambda.util.NamedEnum
-import com.lambda.util.math.MathUtils.ceilToInt
+import com.lambda.util.PlayerBuildLayerUtils.isInBaritoneSelection
+import com.lambda.util.PlayerBuildLayerUtils.isInFlatten
+import com.lambda.util.PlayerBuildLayerUtils.FlattenMode
+import com.lambda.util.PlayerBuildLayerUtils.inSchematic
 import fi.dy.masa.litematica.data.DataManager
 import fi.dy.masa.litematica.world.SchematicWorldHandler
 import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.Direction
 
 object Printer : Module(
 	name = "Printer",
@@ -66,7 +65,7 @@ object Printer : Module(
 				disable()
 				return@onEnable
 			}
-			buildTask = TickingBlueprint(onTick = {
+			buildTask = TickingBlueprint(buildResultPredicate = { filterBuildResults(it) }) {
 				val schematicWorld = SchematicWorldHandler.getSchematicWorld() ?: return@TickingBlueprint emptyMap()
 				BlockPos.iterateOutwards(player.blockPos, range, range, range)
 					.map { it.blockPos }
@@ -74,7 +73,7 @@ object Printer : Module(
 					.filter { DataManager.getRenderLayerRange().isPositionWithinRange(it) && inSchematic(it) }
 					.associateWith { TargetState.State(schematicWorld.getBlockState(it)) }
 					.filter { air || !it.value.blockState.isAir }
-			}, buildResultPredicate = { filterBuildResults(it) }).build(finishOnDone = false).run()
+			}.build(finishOnDone = false).run()
 		}
 
 		onDisable { buildTask?.cancel(); buildTask = null }
@@ -86,104 +85,30 @@ object Printer : Module(
 	 * @return true if the build result should be built, false if it should be ignored
 	 */
 	private fun SafeContext.filterBuildResults(buildResult: BuildResult): Boolean {
-		if (baritoneSelection) {
-			val inSelection = isInBaritoneSelection(buildResult.pos)
-			if (inverseSelection && inSelection) return false
-			if (!inverseSelection && !inSelection) return false
-		}
+		val inSelection = isInBaritoneSelection(buildResult.pos)
+		if (inverseSelection && inSelection) return false
+		if (!inverseSelection && !inSelection) return false
 
 		if (flattenModeApply == FlattenModeApply.Both) {
-			return isInFlatten(buildResult.pos)
+			return isInFlatten(buildResult.pos, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection)
 		}
 		return when (buildResult) {
 			is InteractResult.Interact -> {
-				if (flattenModeApply != FlattenModeApply.PlaceOnly) {
-					return true
-				}
-				isInFlatten(buildResult.pos)
+				if (flattenModeApply != FlattenModeApply.PlaceOnly) true
+				else isInFlatten(buildResult.pos, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection)
 			}
 			is BreakResult.Break -> {
-				if (flattenModeApply != FlattenModeApply.BreakOnly) {
-					return true
-				}
-				isInFlatten(buildResult.pos)
+				if (flattenModeApply != FlattenModeApply.BreakOnly) true
+				else isInFlatten(buildResult.pos, flattenMode, sneakLowersFlatten, baritoneSelection, inverseSelection)
 			}
 			else -> true
 		}
-	}
-
-	private fun inSchematic(pos: BlockPos): Boolean {
-		val placementManager = DataManager.getSchematicPlacementManager()
-		return placementManager?.getAllPlacementsTouchingChunk(pos)?.any {
-			it.placement.isEnabled && it.bb.containsPos(pos)
-		} ?: false
 	}
 
 	private fun litematicaAvailable(): Boolean = runCatching {
 		Class.forName("fi.dy.masa.litematica.Litematica")
 		true
 	}.getOrDefault(false)
-
-	private fun SafeContext.isInFlatten(pos: BlockPos): Boolean {
-		if (flattenMode == FlattenMode.None) return true
-		if (flattenMode == FlattenMode.Staircase) {
-			val up = pos.up()
-			if ((blockState(up).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up)))
-				|| (blockState(up.east()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.east())))
-				|| (blockState(up.south()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.south())))
-				|| (blockState(up.west()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.west())))
-				|| (blockState(up.north()).isNotEmpty && (!baritoneSelection || isInBaritoneSelection(up.north())))
-			) {
-				return false
-			}
-		}
-
-		val flattenY = player.y.ceilToInt()
-		val playerPos = player.blockPos
-		val flattenLevel =
-			if (sneakLowersFlatten && player.isSneaking) flattenY - 1
-			else flattenY
-
-		if (!flattenMode.isSmart && pos.y < flattenLevel)
-			return false
-
-		if (pos == player.supportingBlockPos) return false
-
-		val playerLookDir = player.horizontalFacing
-		val smartFlattenDir =
-			if (flattenMode == FlattenMode.Smart) playerLookDir
-			else playerLookDir?.opposite
-
-		if (pos.y >= flattenLevel) return true
-
-		val zeroedPos = pos.add(-playerPos.x, -flattenY, -playerPos.z)
-
-		return (zeroedPos.x < 0 && smartFlattenDir == Direction.EAST)
-				|| (zeroedPos.z < 0 && smartFlattenDir == Direction.SOUTH)
-				|| (zeroedPos.x > 0 && smartFlattenDir == Direction.WEST)
-				|| (zeroedPos.z > 0 && smartFlattenDir == Direction.NORTH)
-	}
-
-	private fun isInBaritoneSelection(pos: BlockPos) =
-		if (!baritoneSelection) true
-		else BaritoneManager.primary?.selectionManager?.selections?.any {
-			val min = it.min()
-			val max = it.max()
-			pos.x >= min.x && pos.x <= max.x
-					&& pos.y >= min.y && pos.y <= max.y
-					&& pos.z >= min.z && pos.z <= max.z
-		} ?: false
-
-	private enum class FlattenMode {
-		None,
-		Standard,
-		Smart,
-		ReverseSmart,
-		Staircase;
-
-		val isSmart
-			get() = this == Smart || this == ReverseSmart
-	}
 
 	private enum class FlattenModeApply(
 		override val displayName: String,

--- a/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
+++ b/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
@@ -132,7 +132,6 @@ class BuildTask private constructor(
             .toList()
 
         val viableResults = results
-            .filter { buildResultPredicate.test(it) }
             .filter { result ->
                 val finalResult = (result as? Dependent)?.lastDependency ?: result
                 pendingInteractions.none { it.blockPos == finalResult.pos } &&
@@ -142,6 +141,7 @@ class BuildTask private constructor(
                             else -> buildConfig.interactBlocks
                         })
             }
+            .filter { buildResultPredicate.test(it) }
             .sorted()
 
         val bestResult = viableResults.firstOrNull() ?: return

--- a/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
+++ b/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
@@ -60,7 +60,6 @@ import com.lambda.util.player.SlotUtils.hotbarAndInventoryStacks
 import net.minecraft.entity.ItemEntity
 import net.minecraft.util.math.BlockPos
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.function.Predicate
 
 class BuildTask private constructor(
     private val blueprint: Blueprint,
@@ -68,7 +67,7 @@ class BuildTask private constructor(
     private val collectDrops: Boolean,
     private val lifeMaintenance: Boolean,
     automated: Automated,
-    private val buildResultPredicate: Predicate<BuildResult> = Predicate { true }
+    private val buildResultFilter: SafeContext.(BuildResult) -> Boolean,
 ) : Task<Structure>(), Automated by automated {
     override val name: String get() = "Building $blueprint with ${(breaks / (age / 20.0 + 0.001)).format(precision = 1)} b/s ${(placements / (age / 20.0 + 0.001)).format(precision = 1)} p/s"
 
@@ -141,7 +140,7 @@ class BuildTask private constructor(
                             else -> buildConfig.interactBlocks
                         })
             }
-            .filter { buildResultPredicate.test(it) }
+            .filter { buildResultFilter(it) }
             .sorted()
 
         val bestResult = viableResults.firstOrNull() ?: return
@@ -246,9 +245,9 @@ class BuildTask private constructor(
             finishOnDone: Boolean = true,
             collectDrops: Boolean = buildConfig.collectDrops,
             lifeMaintenance: Boolean = false,
-            buildResultPredicate: Predicate<BuildResult> = Predicate { true },
+            buildResultFilter: SafeContext.(BuildResult) -> Boolean = { true },
             blueprint: () -> Blueprint
-        ) = BuildTask(blueprint(), finishOnDone, collectDrops, lifeMaintenance, this, buildResultPredicate = buildResultPredicate)
+        ) = BuildTask(blueprint(), finishOnDone, collectDrops, lifeMaintenance, this, buildResultFilter)
 
         @Ta5kBuilder
         context(automated: Automated)
@@ -256,8 +255,8 @@ class BuildTask private constructor(
             finishOnDone: Boolean = true,
             collectDrops: Boolean = automated.buildConfig.collectDrops,
             lifeMaintenance: Boolean = false,
-            buildResultPredicate: Predicate<BuildResult> = Predicate { true }
-        ) = BuildTask(toBlueprint(), finishOnDone, collectDrops, lifeMaintenance, automated, buildResultPredicate = buildResultPredicate)
+            buildResultFilter: SafeContext.(BuildResult) -> Boolean = { true },
+        ) = BuildTask(toBlueprint(), finishOnDone, collectDrops, lifeMaintenance, automated, buildResultFilter)
 
         @Ta5kBuilder
         context(automated: Automated)
@@ -265,18 +264,18 @@ class BuildTask private constructor(
             finishOnDone: Boolean = true,
             collectDrops: Boolean = automated.buildConfig.collectDrops,
             lifeMaintenance: Boolean = false,
-            buildResultPredicate: Predicate<BuildResult> = Predicate { true }
-        ) = BuildTask(this, finishOnDone, collectDrops, lifeMaintenance, automated, buildResultPredicate = buildResultPredicate)
+            buildResultFilter: SafeContext.(BuildResult) -> Boolean = { true },
+        ) = BuildTask(this, finishOnDone, collectDrops, lifeMaintenance, automated, buildResultFilter)
 
         @Ta5kBuilder
         fun Automated.breakAndCollectBlock(
             blockPos: BlockPos,
             finishOnDone: Boolean = true,
             lifeMaintenance: Boolean = false,
-            buildResultPredicate: Predicate<BuildResult> = Predicate { true }
+            buildResultFilter: SafeContext.(BuildResult) -> Boolean = { true },
         ) = BuildTask(
-            blockPos.toStructure(TargetState.Air).toBlueprint(),
-            finishOnDone, true, lifeMaintenance, this, buildResultPredicate = buildResultPredicate
+            blockPos.toStructure(TargetState.Empty).toBlueprint(),
+            finishOnDone, true, lifeMaintenance, this, buildResultFilter
         )
     }
 }

--- a/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
+++ b/src/main/kotlin/com/lambda/task/tasks/BuildTask.kt
@@ -60,13 +60,15 @@ import com.lambda.util.player.SlotUtils.hotbarAndInventoryStacks
 import net.minecraft.entity.ItemEntity
 import net.minecraft.util.math.BlockPos
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.function.Predicate
 
 class BuildTask private constructor(
     private val blueprint: Blueprint,
     private val finishOnDone: Boolean,
     private val collectDrops: Boolean,
     private val lifeMaintenance: Boolean,
-    automated: Automated
+    automated: Automated,
+    private val buildResultPredicate: Predicate<BuildResult> = Predicate { true }
 ) : Task<Structure>(), Automated by automated {
     override val name: String get() = "Building $blueprint with ${(breaks / (age / 20.0 + 0.001)).format(precision = 1)} b/s ${(placements / (age / 20.0 + 0.001)).format(precision = 1)} p/s"
 
@@ -130,6 +132,7 @@ class BuildTask private constructor(
             .toList()
 
         val viableResults = results
+            .filter { buildResultPredicate.test(it) }
             .filter { result ->
                 val finalResult = (result as? Dependent)?.lastDependency ?: result
                 pendingInteractions.none { it.blockPos == finalResult.pos } &&
@@ -243,33 +246,37 @@ class BuildTask private constructor(
             finishOnDone: Boolean = true,
             collectDrops: Boolean = buildConfig.collectDrops,
             lifeMaintenance: Boolean = false,
+            buildResultPredicate: Predicate<BuildResult> = Predicate { true },
             blueprint: () -> Blueprint
-        ) = BuildTask(blueprint(), finishOnDone, collectDrops, lifeMaintenance, this)
+        ) = BuildTask(blueprint(), finishOnDone, collectDrops, lifeMaintenance, this, buildResultPredicate = buildResultPredicate)
 
         @Ta5kBuilder
         context(automated: Automated)
         fun Structure.build(
             finishOnDone: Boolean = true,
             collectDrops: Boolean = automated.buildConfig.collectDrops,
-            lifeMaintenance: Boolean = false
-        ) = BuildTask(toBlueprint(), finishOnDone, collectDrops, lifeMaintenance, automated)
+            lifeMaintenance: Boolean = false,
+            buildResultPredicate: Predicate<BuildResult> = Predicate { true }
+        ) = BuildTask(toBlueprint(), finishOnDone, collectDrops, lifeMaintenance, automated, buildResultPredicate = buildResultPredicate)
 
         @Ta5kBuilder
         context(automated: Automated)
         fun Blueprint.build(
             finishOnDone: Boolean = true,
             collectDrops: Boolean = automated.buildConfig.collectDrops,
-            lifeMaintenance: Boolean = false
-        ) = BuildTask(this, finishOnDone, collectDrops, lifeMaintenance, automated)
+            lifeMaintenance: Boolean = false,
+            buildResultPredicate: Predicate<BuildResult> = Predicate { true }
+        ) = BuildTask(this, finishOnDone, collectDrops, lifeMaintenance, automated, buildResultPredicate = buildResultPredicate)
 
         @Ta5kBuilder
         fun Automated.breakAndCollectBlock(
             blockPos: BlockPos,
             finishOnDone: Boolean = true,
-            lifeMaintenance: Boolean = false
+            lifeMaintenance: Boolean = false,
+            buildResultPredicate: Predicate<BuildResult> = Predicate { true }
         ) = BuildTask(
             blockPos.toStructure(TargetState.Air).toBlueprint(),
-            finishOnDone, true, lifeMaintenance, this
+            finishOnDone, true, lifeMaintenance, this, buildResultPredicate = buildResultPredicate
         )
     }
 }

--- a/src/main/kotlin/com/lambda/util/PlayerBuildLayerUtils.kt
+++ b/src/main/kotlin/com/lambda/util/PlayerBuildLayerUtils.kt
@@ -28,13 +28,15 @@ import net.minecraft.util.math.Direction
 
 object PlayerBuildLayerUtils {
 	fun SafeContext.isInFlatten(pos: BlockPos, flattenMode: FlattenMode, sneakLowersFlatten: Boolean, baritoneSelection: Boolean, baritoneSelectionInverted: Boolean): Boolean {
+		if (flattenMode == FlattenMode.None) return true
+
 		if (flattenMode == FlattenMode.Staircase) {
 			val up = pos.up()
-			if ((blockState(up).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up) && !baritoneSelectionInverted)))
-				|| (blockState(up.east()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.east()) && !baritoneSelectionInverted)))
-				|| (blockState(up.south()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.south()) && !baritoneSelectionInverted)))
-				|| (blockState(up.west()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.west()) && !baritoneSelectionInverted)))
-				|| (blockState(up.north()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.north()) && !baritoneSelectionInverted)))
+			if ((blockState(up).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up) == !baritoneSelectionInverted)))
+				|| (blockState(up.east()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.east()) == !baritoneSelectionInverted)))
+				|| (blockState(up.south()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.south()) == !baritoneSelectionInverted)))
+				|| (blockState(up.west()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.west()) == !baritoneSelectionInverted)))
+				|| (blockState(up.north()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.north()) == !baritoneSelectionInverted)))
 			)  { return false }
 		}
 
@@ -72,7 +74,6 @@ object PlayerBuildLayerUtils {
 					&& pos.y >= min.y && pos.y <= max.y
 					&& pos.z >= min.z && pos.z <= max.z
 		} ?: false
-
 
 	fun inSchematic(pos: BlockPos): Boolean {
 		val placementManager = DataManager.getSchematicPlacementManager()

--- a/src/main/kotlin/com/lambda/util/PlayerBuildLayerUtils.kt
+++ b/src/main/kotlin/com/lambda/util/PlayerBuildLayerUtils.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Lambda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.lambda.util
+
+import com.lambda.context.SafeContext
+import com.lambda.interaction.BaritoneManager
+import com.lambda.util.BlockUtils.blockState
+import com.lambda.util.BlockUtils.isNotEmpty
+import com.lambda.util.math.MathUtils.ceilToInt
+import fi.dy.masa.litematica.data.DataManager
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Direction
+
+object PlayerBuildLayerUtils {
+	fun SafeContext.isInFlatten(pos: BlockPos, flattenMode: FlattenMode, sneakLowersFlatten: Boolean, baritoneSelection: Boolean, baritoneSelectionInverted: Boolean): Boolean {
+		if (flattenMode == FlattenMode.Staircase) {
+			val up = pos.up()
+			if ((blockState(up).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up) && !baritoneSelectionInverted)))
+				|| (blockState(up.east()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.east()) && !baritoneSelectionInverted)))
+				|| (blockState(up.south()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.south()) && !baritoneSelectionInverted)))
+				|| (blockState(up.west()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.west()) && !baritoneSelectionInverted)))
+				|| (blockState(up.north()).isNotEmpty && (!baritoneSelection || (isInBaritoneSelection(up.north()) && !baritoneSelectionInverted)))
+			)  { return false }
+		}
+
+		val flattenY = player.y.ceilToInt()
+		val playerPos = player.blockPos
+		val flattenLevel =
+			if (sneakLowersFlatten && player.isSneaking) flattenY - 1
+			else flattenY
+
+		if (!flattenMode.isSmart && pos.y < flattenLevel)
+			return false
+
+		if (pos == player.supportingBlockPos) return false
+
+		val playerLookDir = player.horizontalFacing
+		val smartFlattenDir =
+			if (flattenMode == FlattenMode.Smart) playerLookDir
+			else playerLookDir?.opposite
+
+		if (pos.y >= flattenLevel) return true
+
+		val zeroedPos = pos.add(-playerPos.x, -flattenY, -playerPos.z)
+
+		return (zeroedPos.x < 0 && smartFlattenDir == Direction.EAST)
+				|| (zeroedPos.z < 0 && smartFlattenDir == Direction.SOUTH)
+				|| (zeroedPos.x > 0 && smartFlattenDir == Direction.WEST)
+				|| (zeroedPos.z > 0 && smartFlattenDir == Direction.NORTH)
+	}
+
+	fun isInBaritoneSelection(pos: BlockPos) =
+		BaritoneManager.primary?.selectionManager?.selections?.any {
+			val min = it.min()
+			val max = it.max()
+			pos.x >= min.x && pos.x <= max.x
+					&& pos.y >= min.y && pos.y <= max.y
+					&& pos.z >= min.z && pos.z <= max.z
+		} ?: false
+
+
+	fun inSchematic(pos: BlockPos): Boolean {
+		val placementManager = DataManager.getSchematicPlacementManager()
+		return placementManager?.getAllPlacementsTouchingChunk(pos)?.any {
+			it.placement.isEnabled && it.bb.containsPos(pos)
+		} ?: false
+	}
+
+	enum class FlattenMode {
+		None,
+		Standard,
+		Smart,
+		ReverseSmart,
+		Staircase;
+
+		val isSmart
+			get() = this == Smart || this == ReverseSmart
+	}
+}


### PR DESCRIPTION
Adds a similar flatten mode to the printer as Nuker has. It can be configured to apply to only breaking blocks, placing blocks, or both.
These features are especially useful when building mapart with printer and you want to break and place blocks in the same litematica placement area without having to use nuker.