### PR TITLE
make collection lookups not slow

### DIFF
--- a/src/main/java/com/lambda/mixin/render/WorldRendererMixin.java
+++ b/src/main/java/com/lambda/mixin/render/WorldRendererMixin.java
@@ -127,11 +127,14 @@ public abstract class WorldRendererMixin {
         Set<BlockPos> xRayTargets = OutlineManager.INSTANCE.getXrayBlockStyles().keySet();
         Set<BlockPos> depthTargets = OutlineManager.INSTANCE.getDepthTestedBlockStyles().keySet();
 
+        Set<BlockPos> alreadyCollected = new java.util.HashSet<>();
+        for (BlockEntityRenderState s : renderStates.blockEntityRenderStates) {
+            alreadyCollected.add(s.pos);
+        }
+
         for (BlockPos target : Sets.union(xRayTargets, depthTargets)) {
             if (!this.world.getChunkManager().isChunkLoaded(target.getX() >> 4, target.getZ() >> 4)) continue;
-            boolean alreadyCollected = renderStates.blockEntityRenderStates.stream()
-                    .anyMatch(state -> state.pos.equals(target));
-            if (alreadyCollected) continue;
+            if (alreadyCollected.contains(target)) continue;
 
             BlockEntity blockEntity = this.world.getBlockEntity(target);
             if (blockEntity != null && !blockEntity.isRemoved()) {

--- a/src/main/kotlin/com/lambda/config/Configurable.kt
+++ b/src/main/kotlin/com/lambda/config/Configurable.kt
@@ -140,7 +140,7 @@ abstract class Configurable(
         immutableCollection: Collection<Block> = Registries.BLOCK.toList(),
         description: String = "",
         visibility: () -> Boolean = { true },
-    ) = Setting(name, description, BlockCollectionSetting(immutableCollection, defaultValue.toMutableList()), this, visibility).register()
+    ) = Setting(name, description, BlockCollectionSetting(immutableCollection, LinkedHashSet(defaultValue)), this, visibility).register()
 
 	@JvmName("collectionSetting2")
     fun setting(
@@ -149,7 +149,7 @@ abstract class Configurable(
         immutableCollection: Collection<Item> = Registries.ITEM.toList(),
         description: String = "",
         visibility: () -> Boolean = { true },
-    ) = Setting(name, description, ItemCollectionSetting(immutableCollection, defaultValue.toMutableList()), this, visibility).register()
+    ) = Setting(name, description, ItemCollectionSetting(immutableCollection, LinkedHashSet(defaultValue)), this, visibility).register()
 
 	@JvmName("collectionSetting3")
     inline fun <reified T : Any> setting(
@@ -163,8 +163,8 @@ abstract class Configurable(
     ) = Setting(
 	    name,
 	    description,
-        if (displayClassName) ClassCollectionSetting(immutableList, defaultValue.toMutableList())
-                else CollectionSetting(defaultValue.toMutableList(), immutableList, TypeToken.getParameterized(Collection::class.java, T::class.java).type, serialize),
+        if (displayClassName) ClassCollectionSetting(immutableList, LinkedHashSet(defaultValue))
+                else CollectionSetting(LinkedHashSet(defaultValue), immutableList, TypeToken.getParameterized(Collection::class.java, T::class.java).type, serialize),
 		this,
 	    visibility
 	).register()

--- a/src/main/kotlin/com/lambda/config/settings/collections/ClassCollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/ClassCollectionSetting.kt
@@ -50,7 +50,7 @@ class ClassCollectionSetting<T : Any>(
 	override fun loadFromJson(serialized: JsonElement) {
 		val strList = gson.fromJson<MutableList<String>>(serialized, type)
 			.mapNotNull { str -> immutableCollection.find { it.className == str } }
-			.toMutableList()
+			.toMutableSet()
 
 		value = strList
 	}

--- a/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
+++ b/src/main/kotlin/com/lambda/config/settings/collections/CollectionSetting.kt
@@ -55,7 +55,7 @@ open class CollectionSetting<R : Any>(
 	override var value
 		get() = super.value
 		set(newVal) {
-			super.value = newVal.toMutableList()
+			super.value = LinkedHashSet(newVal)
 		}
 
     private var searchFilter = ""
@@ -121,7 +121,7 @@ open class CollectionSetting<R : Any>(
 			if (serialize) gson.fromJson(serialized, type)
 			else gson.fromJson<Collection<String>>(serialized, strListType)
 				.mapNotNull { str -> immutableCollection.find { it.toString() == str } }
-				.toMutableList()
+				.toMutableSet()
 
 		value = strList
 	}


### PR DESCRIPTION
## what

so the CollectionSetting was using a MutableList this whole time which means every `contains()` call was just going through the entire list one by one. switched it to LinkedHashSet so it actually does the lookup properly

also that stream().anyMatch() in fillBlockEntityRenderStates was kinda rough, it was scanning through every block entity for each outline target every frame. just threw em in a HashSet first now

## why

xray was doing like millions of comparisons per chunk rebuild because isSelected() gets called for basically every block and it was linear scanning a list of ~39 entries each time. thats not great

## test

ran the client, loaded a world, toggled stuff on and off, nothing exploded