### PR TITLE
fix: disable freecam on dimension change

### DIFF
--- a/src/main/kotlin/com/lambda/module/modules/render/Freecam.kt
+++ b/src/main/kotlin/com/lambda/module/modules/render/Freecam.kt
@@ -233,7 +233,7 @@ object Freecam : Module(
 
 		listen<PacketEvent.Receive.Pre> { event ->
 			val packet = event.packet
-			if (packet is PlayerRespawnS2CPacket) toggle()
+			if (packet is PlayerRespawnS2CPacket) disable()
 		}
 	}
 

--- a/src/main/kotlin/com/lambda/module/modules/render/Freecam.kt
+++ b/src/main/kotlin/com/lambda/module/modules/render/Freecam.kt
@@ -27,6 +27,7 @@ import com.lambda.event.events.PlayerEvent
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
 import com.lambda.event.listener.SafeListener.Companion.listen
+import com.lambda.event.listener.UnsafeListener.Companion.listenUnsafe
 import com.lambda.interaction.managers.rotating.IRotationRequest.Companion.rotationRequest
 import com.lambda.interaction.managers.rotating.Rotation
 import com.lambda.interaction.managers.rotating.RotationMode
@@ -231,9 +232,8 @@ object Freecam : Module(
 			mc.crosshairTarget?.let { if (it.type != HitResult.Type.MISS) event.cancel() }
 		}
 
-		listen<PacketEvent.Receive.Pre> { event ->
-			val packet = event.packet
-			if (packet is PlayerRespawnS2CPacket) disable()
+		listenUnsafe<PacketEvent.Receive.Pre> { event ->
+			if (event.packet is PlayerRespawnS2CPacket) disable()
 		}
 	}
 

--- a/src/main/kotlin/com/lambda/module/modules/render/Freecam.kt
+++ b/src/main/kotlin/com/lambda/module/modules/render/Freecam.kt
@@ -22,6 +22,7 @@ import com.lambda.config.AutomationConfig.Companion.setDefaultAutomationConfig
 import com.lambda.config.applyEdits
 import com.lambda.context.SafeContext
 import com.lambda.event.events.MovementEvent
+import com.lambda.event.events.PacketEvent
 import com.lambda.event.events.PlayerEvent
 import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
@@ -55,6 +56,7 @@ import com.lambda.util.world.raycast.RayCastUtils.orMiss
 import net.minecraft.client.network.ClientPlayerEntity
 import net.minecraft.client.option.Perspective
 import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.network.packet.s2c.play.PlayerRespawnS2CPacket
 import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.hit.HitResult
 import net.minecraft.util.math.BlockPos
@@ -227,6 +229,11 @@ object Freecam : Module(
 		listen<RenderEvent.UpdateTarget>({ 1 }) { event -> // Higher priority then RotationManager to run before RotationManager modifies mc.crosshairTarget
 			mc.crosshairTarget = rotation.rayCast(reach, lerpPos).orMiss // Can't be null (otherwise mc will spam "Null returned as 'hitResult', this shouldn't happen!")
 			mc.crosshairTarget?.let { if (it.type != HitResult.Type.MISS) event.cancel() }
+		}
+
+		listen<PacketEvent.Receive.Pre> { event ->
+			val packet = event.packet
+			if (packet is PlayerRespawnS2CPacket) toggle()
 		}
 	}
 


### PR DESCRIPTION
prevents a freeze caused by conflicts between Freecam logic and world reinitialization during teleportation