### PR TITLE
fix: ContainerTransferTask crash when transferring 0-count selection

### DIFF
--- a/src/main/kotlin/com/lambda/interaction/construction/simulation/result/results/GenericResult.kt
+++ b/src/main/kotlin/com/lambda/interaction/construction/simulation/result/results/GenericResult.kt
@@ -99,6 +99,7 @@ sealed class GenericResult : BuildResult() {
 
         context(task: Task<*>, _: AutomatedSafeContext)
         override fun resolve() {
+            if (neededSelection.count == 0) return
             neededSelection.transferByTask(HotbarContainer)?.softFail()?.execute(task)
         }
 

--- a/src/main/kotlin/com/lambda/task/tasks/ContainerTransferTask.kt
+++ b/src/main/kotlin/com/lambda/task/tasks/ContainerTransferTask.kt
@@ -96,10 +96,10 @@ class ContainerTransferTask(
 	}
 
 
-	private fun checkFail(): Boolean =
-		failIfNoMaterial.also {
-			failure(NoMaterialAccessException(stackSelection))
-		}
+	private fun checkFail() {
+		if (failIfNoMaterial) failure(NoMaterialAccessException(stackSelection))
+		else success()
+	}
 
 	private class NoMaterialAccessException(stackSelection: StackSelection) : IllegalStateException("Unable to access $stackSelection.")
 }


### PR DESCRIPTION
Fixes #226 