### PR TITLE
Fix crash with unknown tooltip components (Meteor Compat)

### DIFF
--- a/src/main/java/com/lambda/mixin/render/TooltipComponentMixin.java
+++ b/src/main/java/com/lambda/mixin/render/TooltipComponentMixin.java
@@ -38,11 +38,11 @@ public interface TooltipComponentMixin {
             return;
         }
 
-        if (MapPreview.INSTANCE.isEnabled()) cir.setReturnValue((switch (tooltipData) {
-            case MapPreview.MapComponent mapComponent -> mapComponent;
-            case BundleTooltipData bundleTooltipData -> new BundleTooltipComponent(bundleTooltipData.contents());
-            case ProfilesTooltipComponent.ProfilesData profilesData -> new ProfilesTooltipComponent(profilesData);
-            default -> throw new IllegalArgumentException("Unknown TooltipComponent");
-        }));
+        if (MapPreview.INSTANCE.isEnabled()) switch (tooltipData) {
+            case MapPreview.MapComponent mapComponent -> cir.setReturnValue(mapComponent);
+            case BundleTooltipData bundleTooltipData -> cir.setReturnValue(new BundleTooltipComponent(bundleTooltipData.contents()));
+            case ProfilesTooltipComponent.ProfilesData profilesData -> cir.setReturnValue(new ProfilesTooltipComponent(profilesData));
+            default -> {} // ignore
+        }
     }
 }


### PR DESCRIPTION
# Fix crash with unknown tooltip components (Meteor Compat)

Fixes the crash reported in [this thread](https://discord.com/channels/834570721070022687/1508546671624065164/1508547813511004371) in the Lambda support Discord.

When Lambda encounters an unknown instance of TooltipData it mimics the vanilla logic of throwing an IllegalArgumentException. This is unnecessary and causes crashes when paired with mods like Meteor that create their own classes which implement the TooltipData interface.

This PR fixes that by ignoring unknown implementers instead of throwing on them, allowing the other mods' mixins to handle their implementers properly and avoiding crashes altogether.

### Issue Link
https://discord.com/channels/834570721070022687/1508546671624065164/1508547813511004371
