### PR TITLE
Feat:Module Hiding

### DIFF
--- a/src/main/kotlin/com/lambda/gui/MenuBar.kt
+++ b/src/main/kotlin/com/lambda/gui/MenuBar.kt
@@ -277,7 +277,7 @@ object MenuBar {
                 ModuleRegistry.modules
                     .filter { it.tag == tag }
                     .forEach { module ->
-                        checkbox(module.name, module::showInClickGui)
+                        checkbox(module.name, module.showInClickGui::value)
                     }
             }
         }

--- a/src/main/kotlin/com/lambda/gui/MenuBar.kt
+++ b/src/main/kotlin/com/lambda/gui/MenuBar.kt
@@ -265,7 +265,6 @@ object MenuBar {
     private fun ImGuiBuilder.buildModulesMenu() {
         menu("Module Tag") {
             ModuleTag.defaults.forEach { tag ->
-                // checkbox so the dropdown stays open while toggling several tags.
                 checkbox(tag.name, ImBoolean(ModuleTag.isTagShown(tag))) {
                     ModuleTag.toggleTag(tag)
                 }
@@ -278,8 +277,6 @@ object MenuBar {
                 ModuleRegistry.modules
                     .filter { it.tag == tag }
                     .forEach { module ->
-                        // checkbox (not menuItem) so the dropdown stays open while
-                        // toggling several modules in a row.
                         checkbox(module.name, module::showInClickGui)
                     }
             }

--- a/src/main/kotlin/com/lambda/gui/MenuBar.kt
+++ b/src/main/kotlin/com/lambda/gui/MenuBar.kt
@@ -39,6 +39,7 @@ import com.lambda.imgui.ImGui
 import com.lambda.imgui.ImGui.closeCurrentPopup
 import com.lambda.imgui.flag.ImGuiCol
 import com.lambda.imgui.flag.ImGuiStyleVar
+import com.lambda.imgui.type.ImBoolean
 import com.lambda.imgui.flag.ImGuiWindowFlags
 import com.lambda.interaction.BaritoneHandler
 import com.lambda.module.ModuleRegistry
@@ -264,22 +265,22 @@ object MenuBar {
     private fun ImGuiBuilder.buildModulesMenu() {
         menu("Module Tag") {
             ModuleTag.defaults.forEach { tag ->
-                menuItem(tag.name, selected = ModuleTag.isTagShown(tag)) {
+                // checkbox so the dropdown stays open while toggling several tags.
+                checkbox(tag.name, ImBoolean(ModuleTag.isTagShown(tag))) {
                     ModuleTag.toggleTag(tag)
                 }
             }
         }
         separator()
-        // By Tag → quick enable/disable per module
+        // By Tag → toggle whether each module is shown in the ClickGui layout
         ModuleTag.defaults.forEach { tag ->
             menu(tag.name) {
                 ModuleRegistry.modules
                     .filter { it.tag == tag }
                     .forEach { module ->
-                        menuItem(module.name, selected = module.isEnabled) {
-                            module.toggle()
-                        }
-                        // Optionally, offer a "Settings..." item to focus this module’s details UI.
+                        // checkbox (not menuItem) so the dropdown stays open while
+                        // toggling several modules in a row.
+                        checkbox(module.name, module::showInClickGui)
                     }
             }
         }

--- a/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
+++ b/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
@@ -344,7 +344,7 @@ object ClickGuiLayout : Loadable, Config(
 						}
 
 						ModuleRegistry.modules
-							.filter { it.tag == tag && it.showInClickGui }
+							.filter { it.tag == tag && it.showInClickGui.value }
 							.forEach { with(ModuleEntry(it)) { buildLayout() } }
 
 						val vis = snapOverlays[tag.name]

--- a/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
+++ b/src/main/kotlin/com/lambda/gui/components/ClickGuiLayout.kt
@@ -344,7 +344,7 @@ object ClickGuiLayout : Loadable, Config(
 						}
 
 						ModuleRegistry.modules
-							.filter { it.tag == tag }
+							.filter { it.tag == tag && it.showInClickGui }
 							.forEach { with(ModuleEntry(it)) { buildLayout() } }
 
 						val vis = snapOverlays[tag.name]

--- a/src/main/kotlin/com/lambda/module/Module.kt
+++ b/src/main/kotlin/com/lambda/module/Module.kt
@@ -146,7 +146,7 @@ abstract class Module(
         .onRelease { if (disableOnRelease) disable() }
     val disableOnReleaseSetting = setting("Disable On Release", false) { false }
     val drawSetting = setting("Draw", true, "Draws the module in the module list hud element") { false }
-    val showInClickGuiSetting = setting("Show In ClickGui", true, "Shows the module in the ClickGui layout") { false }
+    val showInClickGui = setting("Show In ClickGui", true, "Shows the module in the ClickGui layout") { false }
 
     var isEnabled by isEnabledSetting
         private set
@@ -155,7 +155,6 @@ abstract class Module(
     val keybind by keybindSetting
     val disableOnRelease by disableOnReleaseSetting
     val draw by drawSetting
-    var showInClickGui by showInClickGuiSetting
 
     override val isMuted: Boolean
         get() = !isEnabled && !alwaysListening

--- a/src/main/kotlin/com/lambda/module/Module.kt
+++ b/src/main/kotlin/com/lambda/module/Module.kt
@@ -146,6 +146,7 @@ abstract class Module(
         .onRelease { if (disableOnRelease) disable() }
     val disableOnReleaseSetting = setting("Disable On Release", false) { false }
     val drawSetting = setting("Draw", true, "Draws the module in the module list hud element") { false }
+    val showInClickGuiSetting = setting("Show In ClickGui", true, "Shows the module in the ClickGui layout") { false }
 
     var isEnabled by isEnabledSetting
         private set
@@ -154,6 +155,7 @@ abstract class Module(
     val keybind by keybindSetting
     val disableOnRelease by disableOnReleaseSetting
     val draw by drawSetting
+    var showInClickGui by showInClickGuiSetting
 
     override val isMuted: Boolean
         get() = !isEnabled && !alwaysListening


### PR DESCRIPTION
### Description
Makes it so that you can hide modules from the gui similar to how categories (or module tags) are able to be hidden. This removes being able to toggle modules from the modules menu item.
