### PR TITLE
Feat: Allow all server addresses

### DIFF
--- a/src/main/java/com/lambda/mixin/network/BlockListCheckerMixin.java
+++ b/src/main/java/com/lambda/mixin/network/BlockListCheckerMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Lambda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.lambda.mixin.network;
+
+import net.minecraft.client.network.Address;
+import net.minecraft.client.network.BlockListChecker;
+import net.minecraft.client.network.ServerAddress;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockListChecker.class)
+public interface BlockListCheckerMixin {
+    @Inject(method = "create", at = @At("HEAD"), cancellable = true)
+    private static void onCreate(CallbackInfoReturnable<BlockListChecker> cir) {
+        cir.setReturnValue(new BlockListChecker() {
+            @Override
+            public boolean isAllowed(Address address) {
+                return true;
+            }
+
+            @Override
+            public boolean isAllowed(ServerAddress address) {
+                return true;
+            }
+        });
+    }
+}

--- a/src/main/resources/lambda.mixins.json
+++ b/src/main/resources/lambda.mixins.json
@@ -22,6 +22,7 @@
     "input.MouseMixin",
     "items.BlockItemMixin",
     "items.FilledMapItemMixin",
+    "network.BlockListCheckerMixin",
     "network.ClientCommonNetworkHandlerMixin",
     "network.ClientConnectionMixin",
     "network.ClientLoginNetworkMixin",


### PR DESCRIPTION
## Issue Link

N/A — no existing issue.

## Description

Replaces Minecraft's `BlockListChecker` factory result with an allow-all implementation. Both resolved `Address` values and entered `ServerAddress` values are accepted, preventing the client from filtering multiplayer server addresses through Minecraft's block-list service.

This follows the approach used by [Meteor Client](https://github.com/MeteorDevelopment/meteor-client/commit/6e5d69133352a1b71d525733535a467dc196a94f).

## Checklist Before Submitting

- [x] Code adheres to the project's style and conventions.
- [x] All 137 tests pass via `gradlew.bat build --no-daemon`.
- [x] Documentation changes are not required for this internal networking behavior.
- [x] The PR is limited to this single purpose.
