### PR TITLE
Fix: Module popup in clickgui opening with lmb

### DIFF
--- a/src/main/kotlin/com/lambda/gui/components/ModuleEntry.kt
+++ b/src/main/kotlin/com/lambda/gui/components/ModuleEntry.kt
@@ -43,7 +43,7 @@ class ModuleEntry(val module: Module): Layout {
         if (isMouseReleased() && suppressedEntryId == entryId) suppressedEntryId = null
 
         ImGui.setNextWindowSizeConstraints(0f, 0f, Float.MAX_VALUE, io.displaySize.y * 0.5f)
-        popupContextItem(popupId, ImGuiPopupFlags.None) {
+        popupContextItem(popupId, ImGuiPopupFlags.MouseButtonRight) {
             buildConfigSettingsContext(module)
         }
     }


### PR DESCRIPTION
It changes an ImGUI flag. One line. Previously when you toggled the module in the gui it also opened the settings for it (annoying) (no longer does that) (no longer annoying).

edit: bug was introduced in 8019a99987deed5cfefd8a4cf3573020f3694a85