### PR TITLE
Target strafe rewrite, the old one was not working

### DIFF
--- a/src/main/java/com/lambda/mixin/entity/ClientPlayerEntityMixin.java
+++ b/src/main/java/com/lambda/mixin/entity/ClientPlayerEntityMixin.java
@@ -90,9 +90,12 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 
     @WrapOperation(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;move(Lnet/minecraft/entity/MovementType;Lnet/minecraft/util/math/Vec3d;)V"))
     private void wrapMove(ClientPlayerEntity instance, MovementType movementType, Vec3d vec3d, Operation<Void> original) {
-        EventFlow.post(new MovementEvent.Player.Pre(movementType, vec3d));
+        MovementEvent.Player.Pre preEvent = new MovementEvent.Player.Pre(movementType, vec3d);
+        EventFlow.post(preEvent);
+        vec3d = preEvent.getMovement();
         original.call(instance, movementType, vec3d);
-        EventFlow.post(new MovementEvent.Player.Post(movementType, vec3d));
+        MovementEvent.Player.Post postEvent = new MovementEvent.Player.Post(movementType, vec3d);
+        EventFlow.post(postEvent);
     }
 
     @WrapOperation(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/input/Input;tick()V"))

--- a/src/main/java/com/lambda/mixin/input/KeyBindingMixin.java
+++ b/src/main/java/com/lambda/mixin/input/KeyBindingMixin.java
@@ -36,7 +36,6 @@ public class KeyBindingMixin {
 
         if (Sprint.INSTANCE.isEnabled()) return true;
         if (Speed.INSTANCE.isEnabled() && Speed.getMode() == Speed.Mode.GrimStrafe) return true;
-        if (TargetStrafe.INSTANCE.isEnabled() && TargetStrafe.isActive()) return true;
         return original;
     }
 }

--- a/src/main/kotlin/com/lambda/event/events/MovementEvent.kt
+++ b/src/main/kotlin/com/lambda/event/events/MovementEvent.kt
@@ -25,7 +25,7 @@ import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.MovementType
 import net.minecraft.util.math.Vec3d
 
-sealed class MovementEvent {
+abstract class MovementEvent {
     /**
      * Represents player movement update events.
      * This event will even be triggered if the player is not moving.
@@ -37,18 +37,18 @@ sealed class MovementEvent {
         /**
          * Event triggered before player movement.
          *
-         * @property movementType The type of movement.
+         * @property movement Type The type of movement.
          * @property movement The movement vector.
          */
         data class Pre(
             override val movementType: MovementType,
-            override val movement: Vec3d,
+            override var movement: Vec3d,
         ) : Player(), ICancellable by Cancellable()
 
         /**
          * Event triggered after player movement.
          *
-         * @property movementType The type of movement.
+         * @property movement Type The type of movement.
          * @property movement The movement vector.
          */
         data class Post(

--- a/src/main/kotlin/com/lambda/event/events/MovementEvent.kt
+++ b/src/main/kotlin/com/lambda/event/events/MovementEvent.kt
@@ -25,7 +25,7 @@ import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.MovementType
 import net.minecraft.util.math.Vec3d
 
-abstract class MovementEvent {
+sealed class MovementEvent {
     /**
      * Represents player movement update events.
      * This event will even be triggered if the player is not moving.

--- a/src/main/kotlin/com/lambda/gui/components/ModuleEntry.kt
+++ b/src/main/kotlin/com/lambda/gui/components/ModuleEntry.kt
@@ -43,7 +43,7 @@ class ModuleEntry(val module: Module): Layout {
         if (isMouseReleased() && suppressedEntryId == entryId) suppressedEntryId = null
 
         ImGui.setNextWindowSizeConstraints(0f, 0f, Float.MAX_VALUE, io.displaySize.y * 0.5f)
-        popupContextItem(popupId, ImGuiPopupFlags.None) {
+        popupContextItem(popupId, ImGuiPopupFlags.MouseButtonRight) {
             buildConfigSettingsContext(module)
         }
     }

--- a/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
+++ b/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
@@ -17,18 +17,22 @@
 
 package com.lambda.module.modules.movement
 
+import com.lambda.config.ConfigEditor.forEachSetting
+import com.lambda.config.ConfigEditor.hideAllExcept
+import com.lambda.config.blocks.WorldLineSettings
+import com.lambda.config.withEdits
 import com.lambda.context.SafeContext
 import com.lambda.event.events.MovementEvent
-import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
 import com.lambda.event.listener.SafeListener.Companion.listen
-import com.lambda.interaction.managers.rotating.Rotation
+import com.lambda.graphics.mc.renderer.ImmediateRenderer.Companion.immediateRenderer
 import com.lambda.interaction.managers.rotating.Rotation.Companion.rotationTo
 import com.lambda.module.Module
 import com.lambda.module.modules.combat.KillAura
 import com.lambda.module.tag.ModuleTag
 import net.minecraft.entity.effect.StatusEffects
 import net.minecraft.util.math.Vec3d
+import java.awt.Color
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
@@ -47,8 +51,19 @@ object TargetStrafe : Module(
     private val needsAura by setting("NeedsAura", true)
     private val antiStuck by setting("AntiStuck", true)
 
-    // private val renderCircle by setting("RenderCircle", true)
-    // private val renderThickness by setting("RenderThickness", 2f, 0.5f..8f, 0.5f, visibility = { renderCircle })
+    private val renderCircle by setting("RenderCircle", true)
+    private val renderCircleColor by setting("RenderCircleColor", Color(255, 255, 255, 100), visibility = { renderCircle })
+    private val renderThickness by configBlock(WorldLineSettings(this))
+         .withEdits {
+             hideAllExcept(
+                 ::distanceScaling,
+                 ::worldWidthSetting,
+                 ::screenWidthSetting
+             )
+             forEachSetting {
+                 visibility { old -> { old() && renderCircle } }
+             }
+         }
 
     private var direction = 1
 
@@ -59,22 +74,19 @@ object TargetStrafe : Module(
 
     init {
         listen<TickEvent.Post> {
-
             if (strafing && autoJump && player.isOnGround) {
                 player.jump()
             }
         }
 
         listen<MovementEvent.Player.Pre> { event ->
-            if (mc.player!!.horizontalCollision && antiStuck) {
+            if (player.horizontalCollision && antiStuck) {
                 switchDirection()
             }
-            val strafe = canStrafe()
-
-            if (strafe) {
-                val rotations = KillAura.target?.let { it1 -> player.eyePos!!.rotationTo(it1.pos) } ?: return@listen
+            if (canStrafe()) {
+                val rotations = KillAura.target?.let { it1 -> player.eyePos?.rotationTo(it1.pos) } ?: return@listen
                 KillAura.target?.let { it1 -> doStrafeAtSpeed(event, rotations.yawF, it1.pos) }
-                val r: Rotation
+                currentTargetVec = KillAura.target?.pos
 
                 strafing = true
             } else {
@@ -82,27 +94,22 @@ object TargetStrafe : Module(
             }
         }
 
-        // listen<RenderEvent.RenderWorld> {
-        //     if (strafing && renderCircle) {
-        //         if (currentTargetVec == null) {
-        //             return@listen
-        //         }
-        //         /*
-        //         todo: make rendering work
-        //         drawCircle(currentTargetVec!!, distanceSetting.toDouble(), distanceColor, 360)
-        //         drawCircle(currentTargetVec!!, currentDistance, playerDistanceColor, 360)
-        //         */
-        //     }
-        // }
-
+         immediateRenderer("TargetStrafe immediate renderer") {
+             if (strafing && renderCircle) {
+                 circleLine(
+                     currentTargetVec ?: return@immediateRenderer,
+                     distanceSetting.toDouble(),
+                     renderCircleColor,
+                     renderThickness.width,
+                     segments = 64
+                 )
+             }
+         }
     }
 
     private fun SafeContext.doStrafeAtSpeed(event: MovementEvent.Player.Pre, rotation: Float, target: Vec3d): Boolean {
-
-
         var playerSpeed = hSpeed
         var jumpVelocity = 0.405
-
         var rotationYaw = rotation + (90f * direction)
 
 
@@ -125,14 +132,12 @@ object TargetStrafe : Module(
 
 
         // jump boost
-
         val jumpboost = player.getStatusEffect(StatusEffects.JUMP_BOOST)
         if (jumpboost != null) {
             jumpVelocity *= jumpboost.amplifier
         }
 
         // speed
-
         val speed = player.getStatusEffect(StatusEffects.SPEED)
         if (speed != null) {
 
@@ -140,69 +145,14 @@ object TargetStrafe : Module(
         }
 
         event.movement = Vec3d(playerSpeed * cos(Math.toRadians((rotationYaw + 90.0f).toDouble())), event.movement.y, playerSpeed * sin(Math.toRadians((rotationYaw + 90.0f).toDouble())))
-
-
         return false
     }
 
     private fun canStrafe(): Boolean {
-        if ((KillAura.isEnabled || !needsAura) && KillAura.target != null) {
-            return true
-        }
-        return false
+        return (KillAura.isEnabled || !needsAura) && KillAura.target != null
     }
 
     private fun switchDirection() {
         direction = -direction
     }
-
-    // private fun drawCircle(center: Vec3d, radius: Double, color: Color, precision: Int) {
-
-
-    //     val linesToDraw = ArrayList<Pair<Vec3d, Vec3d>>()
-
-    //     val magic = precision / 360
-
-    //     var lastPos = center.add(0.0, 0.0, radius)
-
-
-    //     for (i in 0..precision) {
-
-    //         val yaw = i * magic
-
-    //         val x = radius * cos(Math.toRadians((yaw + 90.0f).toDouble()))
-    //         val z = radius * sin(Math.toRadians((yaw + 90.0f).toDouble()))
-
-    //         val newPos = center.add(x, 0.0, z)
-    //         linesToDraw.add(Pair(lastPos, newPos))
-    //         lastPos = newPos
-    //     }
-
-    //     val tessellator: Tessellator?
-    //     try {
-    //         tessellator = Tessellator.getInstance()
-    //     } catch (e: NoSuchFieldError) {
-    //         e.printStackTrace()
-    //         return
-    //     }
-    //     val buffer: BufferBuilder = tessellator.buffer
-
-    //     GL11.glLineWidth(renderThickness)
-    //     //GL11.glHint(GL11.GL_LINE_SMOOTH_HINT, GL11.GL_SMOOTH)
-    //     GlStateManager.disableDepth()
-
-    //     buffer.begin(GL11.GL_LINE_LOOP, DefaultVertexFormats.POSITION_COLOR)
-    //     for (pair in linesToDraw) {
-    //         try {
-    //             buffer.pos(pair.first.x, center.y, pair.first.z).color(color.r, color.g, color.b, color.a).endVertex()
-    //             buffer.pos(pair.second.x, center.y, pair.second.z).color(color.r, color.g, color.b, color.a).endVertex()
-    //         } catch (e: NullPointerException) {
-    //         }
-    //     }
-    //     tessellator.draw()
-
-
-    //     GlStateManager.enableDepth()
-    //     GL11.glLineWidth(1f)
-    // }
 }

--- a/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
+++ b/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
@@ -17,80 +17,192 @@
 
 package com.lambda.module.modules.movement
 
-import com.lambda.event.events.RotationEvent
+import com.lambda.context.SafeContext
+import com.lambda.event.events.MovementEvent
+import com.lambda.event.events.RenderEvent
 import com.lambda.event.events.TickEvent
 import com.lambda.event.listener.SafeListener.Companion.listen
+import com.lambda.interaction.managers.rotating.Rotation
 import com.lambda.interaction.managers.rotating.Rotation.Companion.rotationTo
 import com.lambda.module.Module
 import com.lambda.module.modules.combat.KillAura
 import com.lambda.module.tag.ModuleTag
-import com.lambda.util.math.distSq
-import com.lambda.util.player.MovementUtils.update
-import kotlin.math.pow
+import net.minecraft.entity.effect.StatusEffects
+import net.minecraft.util.math.Vec3d
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 object TargetStrafe : Module(
     name = "TargetStrafe",
-    description = "Automatically strafes around entities",
+    description = "Strafes around a target in a circle. The default settings work great for old NCP.",
     tag = ModuleTag.MOVEMENT,
 ) {
-    private val targetDistance by setting("Strafe Distance", 1.0, 0.0..5.0, 0.1)
-    private val jitterCompensation by setting("Jitter Compensation", 0.0, 0.0..1.0, 0.1)
-    private val stabilize by setting("Stabilize", StabilizationMode.Normal)
+    private val autoJump by setting("AutoJump", true)
+    private val distanceSetting by setting("PreferredDistance", 1f, 0f..6f, 0.1f)
+    private val maxDistance by setting("MaxDistance", 10f, 1f..32f, 0.5f)
+    private val turnAmount by setting("TurnAmount", 5f, 1f..90f, 0.5f)
+    private val hSpeed by setting("HSpeed", 0.2873f, 0.001f..10.0f, 0.0001f)
 
-    enum class StabilizationMode {
-        None,
-        Weak,
-        Normal,
-        Strong
-    }
+    private val needsAura by setting("NeedsAura", true)
+    private val antiStuck by setting("AntiStuck", true)
 
-    private var forwardDirection = 1.0
-    private var strafeDirection = 1.0
+    // private val renderCircle by setting("RenderCircle", true)
+    // private val renderThickness by setting("RenderThickness", 2f, 0.5f..8f, 0.5f, visibility = { renderCircle })
 
-    @JvmStatic
-    val isActive get() = isEnabled && KillAura.isEnabled && KillAura.target != null
+    private var direction = 1
+
+    private var currentDistance = 0.toDouble()
+    private var currentTargetVec: Vec3d? = null
+
+    private var strafing = false
 
     init {
         listen<TickEvent.Post> {
-            if (player.horizontalCollision) strafeDirection *= -1
 
-            if (KillAura.target == null) {
-                forwardDirection = 1.0
-                strafeDirection = 1.0
+            if (strafing && autoJump && player.isOnGround) {
+                player.jump()
             }
         }
 
-        listen<RotationEvent.StrafeInput> { event ->
-            KillAura.target?.let { target ->
-                event.strafeYaw = player.eyePos.rotationTo(target.boundingBox.center).yaw
+        listen<MovementEvent.Player.Pre> { event ->
+            if (mc.player!!.horizontalCollision && antiStuck) {
+                switchDirection()
+            }
+            val strafe = canStrafe()
 
-                val distSq = player.pos distSq target.pos
-                val keepRange = 0.5 * jitterCompensation
+            if (strafe) {
+                val rotations = KillAura.target?.let { it1 -> player.eyePos!!.rotationTo(it1.pos) } ?: return@listen
+                KillAura.target?.let { it1 -> doStrafeAtSpeed(event, rotations.yawF, it1.pos) }
+                val r: Rotation
 
-                forwardDirection = when {
-                    distSq > (targetDistance + keepRange).pow(2) -> 1.0
-                    distSq < (targetDistance - keepRange).pow(2) -> -1.0
-                    else -> forwardDirection
-                }
-
-                // Premium code, do not touch it bites
-                var shouldStabilize = when (stabilize) {
-                    StabilizationMode.None -> false
-                    StabilizationMode.Weak -> player.age % 4 == 0   // 1/4
-                    StabilizationMode.Normal -> player.age % 2 == 0 // 2/4
-                    StabilizationMode.Strong -> player.age % 4 != 0 // 3/4
-                }
-
-                shouldStabilize = shouldStabilize && distSq > (targetDistance + 0.5).pow(2)
-
-                val strafe = if (shouldStabilize) 0.0 else strafeDirection
-                event.input.update(forwardDirection, strafe, jump = true)
+                strafing = true
+            } else {
+                strafing = false
             }
         }
 
-        onEnable {
-            forwardDirection = 1.0
-            strafeDirection = 1.0
-        }
+        // listen<RenderEvent.RenderWorld> {
+        //     if (strafing && renderCircle) {
+        //         if (currentTargetVec == null) {
+        //             return@listen
+        //         }
+        //         /*
+        //         todo: make rendering work
+        //         drawCircle(currentTargetVec!!, distanceSetting.toDouble(), distanceColor, 360)
+        //         drawCircle(currentTargetVec!!, currentDistance, playerDistanceColor, 360)
+        //         */
+        //     }
+        // }
+
     }
+
+    private fun SafeContext.doStrafeAtSpeed(event: MovementEvent.Player.Pre, rotation: Float, target: Vec3d): Boolean {
+
+
+        var playerSpeed = hSpeed
+        var jumpVelocity = 0.405
+
+        var rotationYaw = rotation + (90f * direction)
+
+
+        val disX = player.pos.x - target.x
+        val disZ = player.pos.z - target.z
+
+        val distance = sqrt(disX * disX + disZ * disZ)
+
+        if (distance < maxDistance) {
+            if (distance > distanceSetting) {
+                rotationYaw -= turnAmount * direction
+            } else if (distance < distanceSetting) {
+                rotationYaw += turnAmount * direction
+            }
+        } else {
+            rotationYaw = rotation
+        }
+
+        currentDistance = distance
+
+
+        // jump boost
+
+        val jumpboost = player.getStatusEffect(StatusEffects.JUMP_BOOST)
+        if (jumpboost != null) {
+            jumpVelocity *= jumpboost.amplifier
+        }
+
+        // speed
+
+        val speed = player.getStatusEffect(StatusEffects.SPEED)
+        if (speed != null) {
+
+            playerSpeed *= 1.0f + 0.2f * (speed.amplifier + 1)
+        }
+
+        event.movement = Vec3d(playerSpeed * cos(Math.toRadians((rotationYaw + 90.0f).toDouble())), event.movement.y, playerSpeed * sin(Math.toRadians((rotationYaw + 90.0f).toDouble())))
+
+
+        return false
+    }
+
+    private fun canStrafe(): Boolean {
+        if ((KillAura.isEnabled || !needsAura) && KillAura.target != null) {
+            return true
+        }
+        return false
+    }
+
+    private fun switchDirection() {
+        direction = -direction
+    }
+
+    // private fun drawCircle(center: Vec3d, radius: Double, color: Color, precision: Int) {
+
+
+    //     val linesToDraw = ArrayList<Pair<Vec3d, Vec3d>>()
+
+    //     val magic = precision / 360
+
+    //     var lastPos = center.add(0.0, 0.0, radius)
+
+
+    //     for (i in 0..precision) {
+
+    //         val yaw = i * magic
+
+    //         val x = radius * cos(Math.toRadians((yaw + 90.0f).toDouble()))
+    //         val z = radius * sin(Math.toRadians((yaw + 90.0f).toDouble()))
+
+    //         val newPos = center.add(x, 0.0, z)
+    //         linesToDraw.add(Pair(lastPos, newPos))
+    //         lastPos = newPos
+    //     }
+
+    //     val tessellator: Tessellator?
+    //     try {
+    //         tessellator = Tessellator.getInstance()
+    //     } catch (e: NoSuchFieldError) {
+    //         e.printStackTrace()
+    //         return
+    //     }
+    //     val buffer: BufferBuilder = tessellator.buffer
+
+    //     GL11.glLineWidth(renderThickness)
+    //     //GL11.glHint(GL11.GL_LINE_SMOOTH_HINT, GL11.GL_SMOOTH)
+    //     GlStateManager.disableDepth()
+
+    //     buffer.begin(GL11.GL_LINE_LOOP, DefaultVertexFormats.POSITION_COLOR)
+    //     for (pair in linesToDraw) {
+    //         try {
+    //             buffer.pos(pair.first.x, center.y, pair.first.z).color(color.r, color.g, color.b, color.a).endVertex()
+    //             buffer.pos(pair.second.x, center.y, pair.second.z).color(color.r, color.g, color.b, color.a).endVertex()
+    //         } catch (e: NullPointerException) {
+    //         }
+    //     }
+    //     tessellator.draw()
+
+
+    //     GlStateManager.enableDepth()
+    //     GL11.glLineWidth(1f)
+    // }
 }

--- a/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
+++ b/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
@@ -109,7 +109,6 @@ object TargetStrafe : Module(
 
     private fun SafeContext.doStrafeAtSpeed(event: MovementEvent.Player.Pre, rotation: Float, target: Vec3d): Boolean {
         var playerSpeed = hSpeed
-        var jumpVelocity = 0.405
         var rotationYaw = rotation + (90f * direction)
 
 
@@ -129,13 +128,6 @@ object TargetStrafe : Module(
         }
 
         currentDistance = distance
-
-
-        // jump boost
-        val jumpboost = player.getStatusEffect(StatusEffects.JUMP_BOOST)
-        if (jumpboost != null) {
-            jumpVelocity *= jumpboost.amplifier
-        }
 
         // speed
         val speed = player.getStatusEffect(StatusEffects.SPEED)

--- a/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
+++ b/src/main/kotlin/com/lambda/module/modules/movement/TargetStrafe.kt
@@ -52,7 +52,7 @@ object TargetStrafe : Module(
     private val antiStuck by setting("AntiStuck", true)
 
     private val renderCircle by setting("RenderCircle", true)
-    private val renderCircleColor by setting("RenderCircleColor", Color(255, 255, 255, 100), visibility = { renderCircle })
+    private val renderCircleColor by setting("RenderCircleColor", Color(255, 255, 255, 100)) { renderCircle }
     private val renderThickness by configBlock(WorldLineSettings(this))
          .withEdits {
              hideAllExcept(
@@ -67,7 +67,7 @@ object TargetStrafe : Module(
 
     private var direction = 1
 
-    private var currentDistance = 0.toDouble()
+    private var currentDistance = 0.0
     private var currentTargetVec: Vec3d? = null
 
     private var strafing = false


### PR DESCRIPTION
target strafe working :>

the code is [this](https://github.com/KMatias123/targetstrafe-lambda/) ported to the modern lambda base

This commit also modified the ClientPlayerEntityMixin as this needed to be able to set the x and z values

Tested on test.ccbluex.net and it bypasses their updated-ncp, (3.17.1-SNAPSHOT-Updated-b198) (latest build would be 279 so ig that is quite outdated)